### PR TITLE
Fix readbuffer size in WaitForRestOfMessage 

### DIFF
--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -320,7 +320,7 @@ namespace OSDP.Net
         {
             while (replyBuffer.Count < replyLength)
             {
-                byte[] readBuffer = new byte[byte.MaxValue];
+                byte[] readBuffer = new byte[replyLength - replyBuffer.Count];
                 int bytesRead = await TimeOutReadAsync(readBuffer).ConfigureAwait(false);
                 if (bytesRead > 0)
                 {


### PR DESCRIPTION
Fix readbuffer size in WaitForRestOfMessage function so it doesn't read more bytes then it should if working over a slow connection (rs485 usb in windows)