### PR TITLE
Fix so secure channel is able to resume..

### DIFF
--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -59,10 +59,7 @@ namespace OSDP.Net
 
         public Command GetNextCommandData()
         {
-            if (MessageControl.Sequence == 0)
-            {
-                return new PollCommand(Address);
-            }
+
 
             if (_useSecureChannel && !_secureChannel.IsInitialized)
             {
@@ -74,8 +71,15 @@ namespace OSDP.Net
                 return new ServerCryptogramCommand(Address, _secureChannel.ServerCryptogram);
             }
 
+            if (MessageControl.Sequence == 0) 
+            {
+                Console.WriteLine("polling");
+                return new PollCommand(Address);
+            }
+
             if (!_commands.TryDequeue(out var command))
             {
+                Console.WriteLine("polling");
                 return new PollCommand(Address);
             }
 

--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -60,10 +60,14 @@ namespace OSDP.Net
         public Command GetNextCommandData()
         {
 
-
             if (_useSecureChannel && !_secureChannel.IsInitialized)
             {
                 return new SecurityInitializationRequestCommand(Address, _secureChannel.ServerRandomNumber().ToArray());
+            }
+
+            if (MessageControl.Sequence == 0)
+            {
+                return new PollCommand(Address);
             }
 
             if (_useSecureChannel && !_secureChannel.IsEstablished)
@@ -71,15 +75,8 @@ namespace OSDP.Net
                 return new ServerCryptogramCommand(Address, _secureChannel.ServerCryptogram);
             }
 
-            if (MessageControl.Sequence == 0) 
-            {
-                Console.WriteLine("polling");
-                return new PollCommand(Address);
-            }
-
             if (!_commands.TryDequeue(out var command))
             {
-                Console.WriteLine("polling");
                 return new PollCommand(Address);
             }
 


### PR DESCRIPTION
Problem:
If CP is reset/restarted when it's up and running in secure channel mode, communication will immediately fail when started again because Pollcommand is sent before secure channel is set up.  

Solution:
Moved Pollcommand if sequence == 0 after secure channel init checks,  so communication can be resumed if CP (but not the PD's) have been reset/restarted.
