### PR TITLE
Marked busy reply as insecure message

### DIFF
--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -215,9 +215,10 @@ namespace OSDP.Net
                     try
                     {
                         reply = await SendCommandAndReceiveReply(command, device).ConfigureAwait(false);
-                        
+
                         // Prevent plain text message replies when secure channel has been established
-                        if (device.UseSecureChannel && device.IsSecurityEstablished && !reply.IsSecureMessage)
+                        // The busy reply type is a special case which is allowed to be sent as insecure message on a secure channel
+                        if (reply.Type != ReplyType.Busy && device.UseSecureChannel && device.IsSecurityEstablished && !reply.IsSecureMessage)
                         {
                             _logger?.LogWarning("An plain text message was received when the secure channel had been established");
                             device.CreateNewRandomNumber();

--- a/src/OSDP.Net/Messages/Reply.cs
+++ b/src/OSDP.Net/Messages/Reply.cs
@@ -70,7 +70,7 @@ namespace OSDP.Net.Messages
         public ReplyType Type { get; }
         public byte[] ExtractReplyData { get; }
         public IEnumerable<byte> MessageForMacGeneration { get; }
-        public bool IsSecureMessage => SecureSessionMessages.Contains(SecurityBlockType) && Type != ReplyType.Busy;
+        public bool IsSecureMessage => SecureSessionMessages.Contains(SecurityBlockType);
 
         protected abstract byte ReplyCode { get; }
 

--- a/src/OSDP.Net/Messages/Reply.cs
+++ b/src/OSDP.Net/Messages/Reply.cs
@@ -70,7 +70,7 @@ namespace OSDP.Net.Messages
         public ReplyType Type { get; }
         public byte[] ExtractReplyData { get; }
         public IEnumerable<byte> MessageForMacGeneration { get; }
-        public bool IsSecureMessage => SecureSessionMessages.Contains(SecurityBlockType);
+        public bool IsSecureMessage => SecureSessionMessages.Contains(SecurityBlockType) && Type != ReplyType.Busy;
 
         protected abstract byte ReplyCode { get; }
 


### PR DESCRIPTION
Currently the busy reply is handled as a normal reply message. As the busy reply is allowed to be sent as insecure message on a secure channel, the following code is getting triggered, which then resets the device:

```csharp
// Prevent plain text message replies when secure channel has been established
if (device.UseSecureChannel && device.IsSecurityEstablished && !reply.IsSecureMessage)
{
    _logger?.LogWarning("An plain text message was received when the secure channel had been established");
    device.CreateNewRandomNumber();
    ResetDevice(device);
    continue;
}
```

Checking the OSDP documentation, the busy reply should be ignored for secure communication:

> In other words, the busy reply is sent outside the secure channel and should not influence the secured messages that are sent before or after this reply.

With this PR busy replies are not longer marked as secure messages. Alternative / better ways to do this are welcome.