### PR TITLE
Added method to stop a single connection

### DIFF
--- a/src/OSDP.Net.Tests/ControlPanelTest.cs
+++ b/src/OSDP.Net.Tests/ControlPanelTest.cs
@@ -63,6 +63,26 @@ namespace OSDP.Net.Tests
                 TimeSpan.FromSeconds(3));
         }
 
+        [Test]
+        public async Task StopConnectionTest()
+        {
+            // Arrange
+            var connection = new TestConnection();
+            var panel = new ControlPanel();
+
+            Guid id = panel.StartConnection(connection);
+            panel.AddDevice(id, 0, true, false);
+
+            // Act
+            panel.StopConnection(id);
+
+            // Assert
+            await TaskEx.WaitUntil(() => connection.NumberOfTimesCalledOpen == 1, TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromSeconds(3));
+            await TaskEx.WaitUntil(() => connection.NumberOfTimesCalledClose == 1, TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromSeconds(3));
+        }
+
         class TestConnection : IOsdpConnection
         {
             private readonly MemoryStream _stream = new MemoryStream();


### PR DESCRIPTION
While the application is running, I would like to add and remove connections based on user interactions.

The only option I have to remove a connection is to shutdown the whole `ControlPanel` and re-add the connection which should not be closed. Just closing the connection did not work for me, the `Bus` tried to reconnect the connection. I use for all connections the same `ControlPanel` as the comment states:

> If multiple connections are needed, add them to the control panel. Avoid creating multiple control panel objects.

With this PR I added a method to stop a connection based on the given connection identifier.