### PR TITLE
change: Make FileTransfer explicitly async

### DIFF
--- a/src/OSDP.Net/ControlPanel.cs
+++ b/src/OSDP.Net/ControlPanel.cs
@@ -439,10 +439,10 @@ namespace OSDP.Net
         /// <param name="fragmentSize">Initial size of the fragment sent with each packet</param>
         /// <param name="callback">Track the status of the file transfer</param>
         /// <param name="cancellationToken">The CancellationToken token to observe.</param>
-        public void FileTransfer(Guid connectionId, byte address, byte fileType, byte[] fileData, ushort fragmentSize,
+        public Task FileTransfer(Guid connectionId, byte address, byte fileType, byte[] fileData, ushort fragmentSize,
             Action<FileTransferStatus> callback, CancellationToken cancellationToken = default)
         {
-            Task.Factory.StartNew(async () =>
+            return Task.Run(async () =>
             {
                 _buses[connectionId].SetSendingMultiMessage(address, true);
                 try
@@ -455,7 +455,7 @@ namespace OSDP.Net
                     _buses[connectionId].SetSendingMultiMessage(address, false);
                     _buses[connectionId].SetSendingMultiMessageNoSecureChannel(address, false);
                 }
-            }, TaskCreationOptions.LongRunning);
+            });
         }
 
         private async Task SendFileTransferCommands(Guid connectionId, byte address, byte fileType, byte[] fileData,


### PR DESCRIPTION
What do you say about this change?

`FileTransfer` is already async, so let's make that explicit and "by-the-book". By returning the `Task` we let the caller know when we're finished without interpreting the `callback` parameters. It also avoids unobserved exceptions if e.g. we get a timeout exception when sending a command/reply pair. Now those exceptions bubble up the caller instead of potentially crashing the process.
