### PR TITLE
fix: Faster non polling file transfer

### DIFF
--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -215,7 +215,7 @@ namespace OSDP.Net
                         {
                             ResetDevice(device);
                         }
-                        else if(!device.IsConnected)
+                        else if(IsPolling && !device.IsConnected)
                         {
                             device.RequestDelay = DateTime.UtcNow + TimeSpan.FromSeconds(1);
                         }


### PR DESCRIPTION
Non polling connections suffer from a 1 sec delay between each command/reply. This causes slow file transfers where multiple command/reply pairs are exchanged.

This fix ensures the 1 sec delay is only imposed if it is a polling connection that's currently not connected.