### PR TITLE
change: Make StopConnection explicitly async.

### DIFF
--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -348,7 +348,7 @@ namespace Console
             var baudRateTextField = new TextField(25, 5, 25, _settings.TcpClientConnectionSettings.BaudRate.ToString());
             var replyTimeoutTextField = new TextField(25, 7, 25, _settings.SerialConnectionSettings.ReplyTimeout.ToString());
 
-            void StartConnectionButtonClicked()
+            async void StartConnectionButtonClicked()
             {
                 if (!int.TryParse(portNumberTextField.Text.ToString(), out var portNumber))
                 {
@@ -376,7 +376,7 @@ namespace Console
                 _settings.TcpClientConnectionSettings.PortNumber = portNumber;
                 _settings.TcpClientConnectionSettings.ReplyTimeout = replyTimeout;
 
-                StartConnection(new TcpClientOsdpConnection(
+                await StartConnection(new TcpClientOsdpConnection(
                     _settings.TcpClientConnectionSettings.Host,
                     _settings.TcpClientConnectionSettings.PortNumber,
                     _settings.TcpClientConnectionSettings.BaudRate));

--- a/src/Console/Program.cs
+++ b/src/Console/Program.cs
@@ -46,7 +46,7 @@ namespace Console
 
         private static Settings _settings;
 
-        private static void Main()
+        private static async Task Main()
         {
             XmlConfigurator.Configure(
                 LogManager.GetRepository(Assembly.GetAssembly(typeof(LogManager))),
@@ -96,7 +96,7 @@ namespace Console
                     new MenuItem("Stop Connections", "", () =>
                     {
                         _connectionId = Guid.Empty;
-                        _controlPanel.Shutdown();
+                        _ = _controlPanel.Shutdown();
                     })
                 }),
                 DevicesMenuBarItem,
@@ -155,7 +155,7 @@ namespace Console
 
             Application.Run();
 
-            _controlPanel.Shutdown();
+            await _controlPanel.Shutdown();
         }
 
         private static void RegisterEvents()
@@ -229,7 +229,7 @@ namespace Console
             var replyTimeoutTextField =
                 new TextField(25, 5, 25, _settings.SerialConnectionSettings.ReplyTimeout.ToString());
 
-            void StartConnectionButtonClicked()
+            async void StartConnectionButtonClicked()
             {
                 if (string.IsNullOrEmpty(portNameComboBox.Text.ToString()))
                 {
@@ -255,7 +255,7 @@ namespace Console
                 _settings.SerialConnectionSettings.BaudRate = baudRate;
                 _settings.SerialConnectionSettings.ReplyTimeout = replyTimeout;
 
-                StartConnection(new SerialPortOsdpConnection(_settings.SerialConnectionSettings.PortName,
+                await StartConnection(new SerialPortOsdpConnection(_settings.SerialConnectionSettings.PortName,
                         _settings.SerialConnectionSettings.BaudRate)
                     { ReplyTimeout = TimeSpan.FromMilliseconds(_settings.SerialConnectionSettings.ReplyTimeout) });
 
@@ -288,7 +288,7 @@ namespace Console
             var replyTimeoutTextField =
                 new TextField(25, 5, 25, _settings.SerialConnectionSettings.ReplyTimeout.ToString());
 
-            void StartConnectionButtonClicked()
+            async void StartConnectionButtonClicked()
             {
                 if (!int.TryParse(portNumberTextField.Text.ToString(), out var portNumber))
                 {
@@ -315,7 +315,7 @@ namespace Console
                 _settings.TcpServerConnectionSettings.BaudRate = baudRate;
                 _settings.TcpServerConnectionSettings.ReplyTimeout = replyTimeout;
 
-                StartConnection(new TcpServerOsdpConnection(_settings.TcpServerConnectionSettings.PortNumber,
+                await StartConnection(new TcpServerOsdpConnection(_settings.TcpServerConnectionSettings.PortNumber,
                         _settings.TcpServerConnectionSettings.BaudRate)
                     { ReplyTimeout = TimeSpan.FromMilliseconds(_settings.TcpServerConnectionSettings.ReplyTimeout) });
 
@@ -438,13 +438,13 @@ namespace Console
             Application.Run(dialog);
         }
 
-        private static void StartConnection(IOsdpConnection osdpConnection)
+        private static async Task StartConnection(IOsdpConnection osdpConnection)
         {
             LastNak.Clear();
 
             if (_connectionId != Guid.Empty)
             {
-                _controlPanel.Shutdown();
+                await _controlPanel.Shutdown();
             }
 
             _connectionId =

--- a/src/OSDP.Net.Tests/ControlPanelTest.cs
+++ b/src/OSDP.Net.Tests/ControlPanelTest.cs
@@ -73,7 +73,7 @@ namespace OSDP.Net.Tests
 
             // Act/Assert
             var ex = Assert.Throws<InvalidOperationException>(() => panel.StartConnection(connection), "");
-            Assert.That(ex.Message, Is.EqualTo(
+            Assert.That(ex?.Message, Is.EqualTo(
                 $"The IOsdpConnection is already active in connection {id}. " +
                     "That connection must be stopped before starting a new one."));
         }

--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -153,12 +153,7 @@ namespace OSDP.Net
             if(_pollingTask == null)
             { 
                 _isShuttingDown = false;
-                // This ensures that polling is started in a separate thread.
-                _pollingTask = Task.Factory.StartNew(
-                    async () => await StartPollingAsync(),
-                    CancellationToken.None,
-                    TaskCreationOptions.LongRunning,
-                    TaskScheduler.Default);
+                _pollingTask = Task.Run(() => StartPollingAsync());
             }
         }
 

--- a/src/OSDP.Net/ControlPanel.cs
+++ b/src/OSDP.Net/ControlPanel.cs
@@ -88,10 +88,7 @@ namespace OSDP.Net
 
             _buses[newBus.Id] = newBus;
 
-            Task.Factory.StartNew(async () =>
-            {
-                await newBus.StartPollingAsync().ConfigureAwait(false);
-            }, TaskCreationOptions.LongRunning);
+            newBus.StartPolling();
 
             return newBus.Id;
         }
@@ -100,7 +97,7 @@ namespace OSDP.Net
         /// Stop the bus for a specific connection.
         /// </summary>
         /// <param name="connectionId">The identifier that represents the connection.</param>
-        public void StopConnection(Guid connectionId)
+        public async Task StopConnection(Guid connectionId)
         {
             if (!_buses.TryRemove(connectionId, out Bus bus))
             {
@@ -108,7 +105,7 @@ namespace OSDP.Net
             }
 
             bus.ConnectionStatusChanged -= BusOnConnectionStatusChanged;
-            bus.Close();
+            await bus.Close();
 
             foreach (byte address in bus.ConfigureDeviceAddresses)
             {
@@ -864,12 +861,12 @@ namespace OSDP.Net
         /// <summary>
         /// Shutdown the control panel and stop all communication to PDs.
         /// </summary>
-        public void Shutdown()
+        public async Task Shutdown()
         {
             foreach (var bus in _buses.Values)
             {
                 bus.ConnectionStatusChanged -= BusOnConnectionStatusChanged;
-                bus.Close();
+                await bus.Close();
                 
                 foreach (byte address in bus.ConfigureDeviceAddresses)
                 {

--- a/src/samples/PivDataReader/Program.cs
+++ b/src/samples/PivDataReader/Program.cs
@@ -96,7 +96,7 @@ internal class Program
             if (!exit) Console.Clear();
         }
 
-        panel.Shutdown();
+        await panel.Shutdown();
         
         async Task GetPivData()
         {


### PR DESCRIPTION
By making StopConnection async we expose the inherently async nature of stopping a connection.

Currently, a Poll task is started in StartConnection and then it is signalled to stop in StopConnection. There are a few issues with this.

1. There is no way for the caller to know when the connection is *really* closed. StopConnection only signals the *intention* to close the connection.
2. The connection is closed while the poll thread is running, which can lead to weird problems, e.g. the poll thread writing to a closed connection.
3. Situation 2 can actually lead to the connection being opened up again (see e.g. TcpClientOsdpConnection.WriteAsync()). If so, it will never be closed.

This PR
1. Only closes the connection once the poll thread has exited.
2. Makes StopConnection async to capture the whole process of closing a connection. When the StopConnection task is completed, the connection is guaranteed to be stopped.

Having StopConnection return Task is a "somewhat" breaking change. Old code will compile, but with a warning. To get rid of the warning one can either

```cs
// Ignore the task. More or less the old behavior.
_ = cp.StopConnection()

// or

// Await the task (preferred). This way you have explicit control of the shutdown behavior.
await cp.StopConnection()
```