### PR TITLE
fix: Reset retry counter after successful response.

### DIFF
--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -136,6 +136,8 @@ namespace OSDP.Net
             
             // It's valid once sequences are above zero
             if (sequence > 0) _lastValidReply = DateTime.UtcNow;
+            // Reset retry counter
+            _counter = RetryAmount;
         }
 
         public void InitializeSecureChannel(Reply reply)


### PR DESCRIPTION
Today, only 3 retries *in total* are allowed per connection. This should clearly be 3 retries *per request*.