### PR TITLE
change: Threadsafe start/stop connections.

### DIFF
--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -81,8 +81,6 @@ namespace OSDP.Net
                 _isShuttingDown = true;
                 await _pollingTask;
                 _pollingTask = null;
-                // Polling task is complete. Now it is 100% safe to close the connection.
-                Connection.Close();
             }
         }
 
@@ -305,6 +303,16 @@ namespace OSDP.Net
 
                     delayTime.WaitOne(IdleLineDelay(2));
                 }
+            }
+
+            // Polling task is complete. Time to close the connection.
+            try
+            { 
+                Connection.Close();
+            }
+            catch(Exception exception)
+            {
+                _logger?.LogError(exception, $"Error while closing connection {Id}.");
             }
         }
 


### PR DESCRIPTION
What do you say about this? Basically a mix between yours/mine approach with two changes:

1. Serializes calls to StartConnection by a lock. It's quick so should be no problem.
2. Make StopConnection reentrant, so multiple threads can safely stop the same connection. No locks, so no risk of hanging or delaying here.