### PR TITLE
fix: Wrong exception if connection is broken during file transfer.

### DIFF
--- a/src/OSDP.Net/ControlPanel.cs
+++ b/src/OSDP.Net/ControlPanel.cs
@@ -448,9 +448,10 @@ namespace OSDP.Net
         public Task<Model.ReplyData.FileTransferStatus.StatusDetail> FileTransfer(Guid connectionId, byte address, byte fileType, byte[] fileData, ushort fragmentSize,
             Action<FileTransferStatus> callback, CancellationToken cancellationToken = default)
         {
+            var bus = _buses[connectionId];
             return Task.Run(async () =>
             {
-                _buses[connectionId].SetSendingMultiMessage(address, true);
+                bus.SetSendingMultiMessage(address, true);
                 try
                 {
                     return await SendFileTransferCommands(connectionId, address, fileType, fileData, fragmentSize, callback,
@@ -458,8 +459,8 @@ namespace OSDP.Net
                 }
                 finally
                 {
-                    _buses[connectionId].SetSendingMultiMessage(address, false);
-                    _buses[connectionId].SetSendingMultiMessageNoSecureChannel(address, false);
+                    bus.SetSendingMultiMessage(address, false);
+                    bus.SetSendingMultiMessageNoSecureChannel(address, false);
                 }
             }, cancellationToken);
         }


### PR DESCRIPTION
If a connection is lost during a file transfer (e.g. serial port is disconnected), the transfer will fail and an exception is thrown. This is expected, naturally.

However, the connection is also removed from `_buses` so the finally block will throw "The given key 'xxx' was not present in the dictionary.' and the "real" exception is lost.