### PR TITLE
Moved new secure channel implementation into osdp.net lib

### DIFF
--- a/src/OSDP.Net.Tests/Model/CommandData/GetPIVDataTest.cs
+++ b/src/OSDP.Net.Tests/Model/CommandData/GetPIVDataTest.cs
@@ -1,0 +1,40 @@
+﻿using NUnit.Framework;
+using OSDP.Net.Model.CommandData;
+using OSDP.Net.Utilities;
+using System;
+using System.Linq;
+
+namespace OSDP.Net.Tests.Model.CommandData
+{
+    internal class GetPIVDataTest
+    {
+        [Test]
+        public void BuildData() 
+        {
+            var command = new GetPIVData(ObjectId.CardholderUniqueIdentifier, 1, 25);
+
+            var actual = command.BuildData().ToArray();
+            Assert.That(BitConverter.ToString(actual), Is.EqualTo("5F-C1-02-01-19"));
+        }
+
+        [Test]
+        public void BuildData2()
+        {
+            var command = new GetPIVData(new byte[] { 0x5F, 0xC1, 0x02 }, 1, 25);
+
+            var actual = command.BuildData().ToArray();
+            Assert.That(BitConverter.ToString(actual), Is.EqualTo("5F-C1-02-01-19-00"));
+        }
+
+        [TestCase("5F-C1-02-01-19-00")]
+        [TestCase("5F-C1-02-01-19")]
+        public void ParseData(string inputData)
+        {
+            var actual = GetPIVData.ParseData(BinaryUtils.HexToBytes(inputData).ToArray());
+
+            Assert.That(actual.ObjectId, Is.EquivalentTo(new byte[] { 0x5F, 0xC1, 0x02 }));
+            Assert.That(actual.ElementId, Is.EqualTo(1));
+            Assert.That(actual.DataOffset, Is.EqualTo(25));
+        }
+    }
+}

--- a/src/OSDP.Net.Tests/Model/CommandData/GetPIVDataTest.cs
+++ b/src/OSDP.Net.Tests/Model/CommandData/GetPIVDataTest.cs
@@ -9,15 +9,6 @@ namespace OSDP.Net.Tests.Model.CommandData
     internal class GetPIVDataTest
     {
         [Test]
-        public void BuildData() 
-        {
-            var command = new GetPIVData(ObjectId.CardholderUniqueIdentifier, 1, 25);
-
-            var actual = command.BuildData().ToArray();
-            Assert.That(BitConverter.ToString(actual), Is.EqualTo("5F-C1-02-01-19"));
-        }
-
-        [Test]
         public void BuildData2()
         {
             var command = new GetPIVData(new byte[] { 0x5F, 0xC1, 0x02 }, 1, 25);

--- a/src/OSDP.Net.Tests/Model/CommandData/OutputControlTest.cs
+++ b/src/OSDP.Net.Tests/Model/CommandData/OutputControlTest.cs
@@ -1,0 +1,30 @@
+﻿using NUnit.Framework;
+using OSDP.Net.Model.CommandData;
+using OSDP.Net.Utilities;
+using System;
+using System.Linq;
+
+namespace OSDP.Net.Tests.Model.CommandData
+{
+    internal class OutputControlTest
+    {
+        [Test]
+        public void BuildData()
+        {
+            var actual = new OutputControl(5, OutputControlCode.PermanentStateOnAllowTimedOperation, 10000).BuildData().ToArray();
+
+            Assert.That(BitConverter.ToString(actual), Is.EqualTo("05-04-10-27"));
+        }
+
+        [Test]
+        public void ParseData()
+        {
+            var inputData = BinaryUtils.HexToBytes("05-04-10-27").ToArray();
+            var actual = OutputControl.ParseData(inputData);
+
+            Assert.That(actual.OutputNumber, Is.EqualTo(5));
+            Assert.That(actual.OutputControlCode, Is.EqualTo(OutputControlCode.PermanentStateOnAllowTimedOperation));
+            Assert.That(actual.Timer, Is.EqualTo(10000));
+        }
+    }
+}

--- a/src/OSDP.Net.Tests/Model/CommandData/ReaderBuzzerControlTest.cs
+++ b/src/OSDP.Net.Tests/Model/CommandData/ReaderBuzzerControlTest.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using OSDP.Net.Utilities;
+using System.Linq;
+using OSDP.Net.Model.CommandData;
+
+namespace OSDP.Net.Tests.Model.CommandData
+{
+    internal class ReaderBuzzerControlTest
+    {
+        [Test]
+        public void ParseData()
+        {
+            var inputData = BinaryUtils.HexToBytes("00-02-05-02-01").ToArray();
+
+            var actual = ReaderBuzzerControl.ParseData(inputData);
+
+            Assert.That(actual.ReaderNumber, Is.EqualTo(0));
+            Assert.That(actual.ToneCode, Is.EqualTo(ToneCode.Default));
+            Assert.That(actual.OnTime, Is.EqualTo(5));
+            Assert.That(actual.OffTime, Is.EqualTo(2));
+            Assert.That(actual.Count, Is.EqualTo(1));
+        }
+    }
+}
+ 

--- a/src/OSDP.Net.Tests/Model/CommandData/ReaderTextOutputTest.cs
+++ b/src/OSDP.Net.Tests/Model/CommandData/ReaderTextOutputTest.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using OSDP.Net.Utilities;
+using System.Linq;
+using OSDP.Net.Model.CommandData;
+
+namespace OSDP.Net.Tests.Model.CommandData
+{
+    internal class ReaderTextOutputTest
+    {
+        [Test]
+        public void ParseData()
+        {
+            var inputData = BinaryUtils.HexToBytes("00-02-00-01-01-18-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A-2A").ToArray();
+
+            var actual = ReaderTextOutput.ParseData(inputData);
+
+            Assert.That(actual.ReaderNumber, Is.EqualTo(0));
+            Assert.That(actual.TextCommand, Is.EqualTo(TextCommand.PermanentTextWithWrap));
+            Assert.That(actual.TemporaryTextTime, Is.EqualTo(0));
+            Assert.That(actual.Row, Is.EqualTo(1));
+            Assert.That(actual.Column, Is.EqualTo(1));
+            Assert.That(actual.Text, Is.EqualTo("************************"));
+        }
+    }
+}

--- a/src/OSDP.Net.Tests/Model/ReplyData/ChallengeResponseTest.cs
+++ b/src/OSDP.Net.Tests/Model/ReplyData/ChallengeResponseTest.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using NUnit.Framework;
+using OSDP.Net.Model.ReplyData;
+using OSDP.Net.Utilities;
+
+namespace OSDP.Net.Tests.Model.ReplyData
+{
+    internal class ChallengeResponseTest
+    {
+        [Test]
+        public void ParseData()
+        {
+            var data = BinaryUtils.HexToBytes(
+                "01-02-03-04-05-06-07-08-11-22-33-44-55-66-77-88-00-10-20-30-40-50-60-70-80-90-A0-B0-C0-D0-E0-F0").ToArray();
+            var actual = ChallengeResponse.ParseData(data);
+
+            Assert.That(BitConverter.ToString(actual.ClientUID), Is.EqualTo("01-02-03-04-05-06-07-08"));
+            Assert.That(BitConverter.ToString(actual.RndB), Is.EqualTo("11-22-33-44-55-66-77-88"));
+            Assert.That(BitConverter.ToString(actual.Cryptogram), Is.EqualTo("00-10-20-30-40-50-60-70-80-90-A0-B0-C0-D0-E0-F0"));
+        }
+
+        [Test]
+        public void BuildData()
+        {
+            var cUID = new byte[] { 1, 2, 3, 4, 5, 6, 7, 8 };
+            var rndB = new byte[] { 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88 };
+            var cryptogram = new byte[] { 
+                0x00, 0x10, 0x20, 0x30, 0x40, 0x50, 0x60, 0x70, 0x80, 0x90, 0xA0, 0xB0, 0xC0, 0xD0, 0xE0, 0xF0 };
+
+            var actual = new ChallengeResponse(cUID, rndB, cryptogram).BuildData();
+
+            Assert.That(BitConverter.ToString(actual), Is.EqualTo(
+                "01-02-03-04-05-06-07-08-11-22-33-44-55-66-77-88-00-10-20-30-40-50-60-70-80-90-A0-B0-C0-D0-E0-F0"
+            ));
+        }
+    }
+}

--- a/src/OSDP.Net.Tests/Utilities/BinaryTest.cs
+++ b/src/OSDP.Net.Tests/Utilities/BinaryTest.cs
@@ -15,6 +15,13 @@ namespace OSDP.Net.Tests.Utilities
         }
 
         [Test]
+        public void HexWithDashSeparatorsToBytes()
+        {
+            var actual = BinaryUtils.HexToBytes("01-23-45-67-89-ab").ToArray();
+            Assert.That(actual, Is.EquivalentTo(new byte[] { 0x01, 0x23, 0x45, 0x67, 0x89, 0xab }));
+        }
+
+        [Test]
         public void HexStringToBitArray()
         {
             var actual = BinaryUtils.HexStringToBitArray("0123");

--- a/src/OSDP.Net/Exceptions.cs
+++ b/src/OSDP.Net/Exceptions.cs
@@ -16,6 +16,9 @@ namespace OSDP.Net
         /// <param name="message">Message that describes the error</param>
         public OSDPNetException(string message) : base(message) {}
 
+        /// <summary>
+        /// Initializes a new instance of OSDP.Net.OSDPNetException
+        /// </summary>
         public OSDPNetException() : base() { }
     }
 
@@ -46,13 +49,28 @@ namespace OSDP.Net
         public override string Message { get; }
     }
 
+    /// <summary>
+    /// Gets thrown whenever OSDP.NET is unable to parse payload bytes
+    /// </summary>
     public class InvalidPayloadException : OSDPNetException
     {
+        /// <summary>
+        /// Initializes a new instance of OSDP.Net.InvalidPayloadException with a specified
+        /// error message
+        /// </summary>
+        /// <param name="message">Optional message to be included with the exception</param>
         public InvalidPayloadException(string message) : base(message) { }
     }
 
+    /// <summary>
+    /// Exception that gets thrown if the attempted operation expects channel security 
+    /// to be established
+    /// </summary>
     public class SecureChannelRequired : OSDPNetException
     {
+        /// <summary>
+        /// Initializes a new instance of OSDP.Net.SecureChannelRequired
+        /// </summary>
         public SecureChannelRequired() : base() { }
     }
 }

--- a/src/OSDP.Net/Exceptions.cs
+++ b/src/OSDP.Net/Exceptions.cs
@@ -15,6 +15,8 @@ namespace OSDP.Net
         /// </summary>
         /// <param name="message">Message that describes the error</param>
         public OSDPNetException(string message) : base(message) {}
+
+        public OSDPNetException() : base() { }
     }
 
     /// <summary>
@@ -42,5 +44,15 @@ namespace OSDP.Net
 
         /// <inheritdoc />
         public override string Message { get; }
+    }
+
+    public class InvalidPayloadException : OSDPNetException
+    {
+        public InvalidPayloadException(string message) : base(message) { }
+    }
+
+    public class SecureChannelRequired : OSDPNetException
+    {
+        public SecureChannelRequired() : base() { }
     }
 }

--- a/src/OSDP.Net/Exceptions.cs
+++ b/src/OSDP.Net/Exceptions.cs
@@ -7,19 +7,23 @@ namespace OSDP.Net
     /// <summary>
     /// Represents a custom exception defined in OSDP.Net library
     /// </summary>
-    public class OSDPNetException : Exception 
+    public class OSDPNetException : Exception
     {
         /// <summary>
         /// Initializes a new instance of OSDP.Net.OSDPNetException with a specified
         /// error message
         /// </summary>
         /// <param name="message">Message that describes the error</param>
-        public OSDPNetException(string message) : base(message) {}
+        public OSDPNetException(string message) : base(message)
+        {
+        }
 
         /// <summary>
         /// Initializes a new instance of OSDP.Net.OSDPNetException
         /// </summary>
-        public OSDPNetException() : base() { }
+        public OSDPNetException()
+        {
+        }
     }
 
     /// <summary>
@@ -71,6 +75,8 @@ namespace OSDP.Net
         /// <summary>
         /// Initializes a new instance of OSDP.Net.SecureChannelRequired
         /// </summary>
-        public SecureChannelRequired() : base() { }
+        public SecureChannelRequired()
+        {
+        }
     }
 }

--- a/src/OSDP.Net/Messages/IMessageChannel.cs
+++ b/src/OSDP.Net/Messages/IMessageChannel.cs
@@ -25,14 +25,15 @@ namespace OSDP.Net.Messages
         /// <param name="destination">Identifies where encoded data is to written to</param>
         void EncodePayload(byte[] payload, Span<byte> destination);
 
+        byte[] DecodePayload(byte[] payload);
+
         /// <summary>
         /// Generates a new Message Authentication Code. Note this command IS NOT
         /// idempotent as every time it is called it will calculate a new rolling MAC
         /// value based on the results of the previous call
         /// </summary>
         /// <param name="message">Message to be signed with a MAC</param>
-        /// <param name="isCommand">Indicates whether the message is a command or a response</param>
         /// <returns></returns>
-        ReadOnlySpan<byte> GenerateMac(ReadOnlySpan<byte> message, bool isCommand);
+        ReadOnlySpan<byte> GenerateMac(ReadOnlySpan<byte> message, bool isIncoming);
     }
 }

--- a/src/OSDP.Net/Messages/IMessageChannel.cs
+++ b/src/OSDP.Net/Messages/IMessageChannel.cs
@@ -25,6 +25,18 @@ namespace OSDP.Net.Messages
         /// <param name="destination">Identifies where encoded data is to written to</param>
         void EncodePayload(byte[] payload, Span<byte> destination);
 
+        /// <summary>
+        /// Decodes the payload using the secure channel context. This function can
+        /// only be called once IsSecurityEstablished is true
+        /// </summary>
+        /// <param name="payload">Payload to be decrypted</param>
+        /// <returns>
+        /// Plaintext message payload. Similarly to how original payload must have been
+        /// padded prior to being encrypted, the plaintext byte buffer returned here will
+        /// also be padded and therefore its length will always be divisible by 16. The 
+        /// padding at the end of the buffer will always consist of zero or more 0x00
+        /// bytes preceeded by 0x80 byte.
+        /// </returns>
         byte[] DecodePayload(byte[] payload);
 
         /// <summary>
@@ -33,7 +45,10 @@ namespace OSDP.Net.Messages
         /// value based on the results of the previous call
         /// </summary>
         /// <param name="message">Message to be signed with a MAC</param>
-        /// <returns></returns>
+        /// <param name="isIncoming">If true, indicates that the message was received
+        /// from the wire. If false, indicates that the message is being sent out 
+        /// on the wire</param>
+        /// <returns>16-byte MAC value of the message</returns>
         ReadOnlySpan<byte> GenerateMac(ReadOnlySpan<byte> message, bool isIncoming);
     }
 }

--- a/src/OSDP.Net/Messages/IncomingMessage.cs
+++ b/src/OSDP.Net/Messages/IncomingMessage.cs
@@ -50,7 +50,10 @@ namespace OSDP.Net.Messages
             {
                 var paddedPayload = channel.DecodePayload(Payload);
                 var lastByteIdx = Payload.Length;
-                while (lastByteIdx > 0 && paddedPayload[--lastByteIdx] != FirstPaddingByte);
+                while (lastByteIdx > 0 && paddedPayload[--lastByteIdx] != FirstPaddingByte)
+                {
+                }
+
                 Payload = paddedPayload.AsSpan().Slice(0, lastByteIdx).ToArray();
             }
 

--- a/src/OSDP.Net/Messages/PD/Reply.cs
+++ b/src/OSDP.Net/Messages/PD/Reply.cs
@@ -76,7 +76,9 @@ namespace OSDP.Net.Messages.PD
                     : (byte)SecurityBlockType.ReplyMessageWithDataSecurity;
 
                 // TODO: How do I determine this properly?? (SCBK vs SCBK-D value)
-                buffer[curLen + 2] = 0x00;
+                // Is this needed only for establishing secure channel? or do we always need to return it
+                // with every reply?
+                buffer[curLen + 2] = 0x01;
                 curLen += 3;
             }
 

--- a/src/OSDP.Net/Model/CommandData/CommandData.cs
+++ b/src/OSDP.Net/Model/CommandData/CommandData.cs
@@ -1,9 +1,4 @@
 ﻿using OSDP.Net.Messages;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OSDP.Net.Model.CommandData
 {

--- a/src/OSDP.Net/Model/CommandData/CommandData.cs
+++ b/src/OSDP.Net/Model/CommandData/CommandData.cs
@@ -1,0 +1,20 @@
+﻿using OSDP.Net.Messages;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OSDP.Net.Model.CommandData
+{
+    /// <summary>
+    /// Base class representing a paylod of a PD command message
+    /// </summary>
+    public abstract class CommandData : PayloadData 
+    {
+        /// <summary>
+        /// Message command code
+        /// </summary>
+        public abstract CommandType CommandType { get; }
+    }
+}

--- a/src/OSDP.Net/Model/CommandData/GetPIVData.cs
+++ b/src/OSDP.Net/Model/CommandData/GetPIVData.cs
@@ -23,10 +23,10 @@ namespace OSDP.Net.Model.CommandData
         {
             ObjectId = objectId switch
             {
-                CommandData.ObjectId.CardholderUniqueIdentifier => new byte[] { 0x5F, 0xC1, 0x02 },
-                CommandData.ObjectId.CertificateForPIVAuthentication => new byte[] { 0x5F, 0xC1, 0x05 },
-                CommandData.ObjectId.CertificateForCardAuthentication => new byte[] { 0xDF, 0xC1, 0x01 },
-                CommandData.ObjectId.CardholderFingerprintTemplate => new byte[] { 0xDF, 0xC1, 0x03 },
+                Model.CommandData.ObjectId.CardholderUniqueIdentifier => new byte[] { 0x5F, 0xC1, 0x02 },
+                Model.CommandData.ObjectId.CertificateForPIVAuthentication => new byte[] { 0x5F, 0xC1, 0x05 },
+                Model.CommandData.ObjectId.CertificateForCardAuthentication => new byte[] { 0xDF, 0xC1, 0x01 },
+                Model.CommandData.ObjectId.CardholderFingerprintTemplate => new byte[] { 0xDF, 0xC1, 0x03 },
                 _ => throw new ArgumentOutOfRangeException()
             };
 
@@ -69,6 +69,9 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public ushort DataOffset { get; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of GetPIVData representing the message payload</returns>
         public static GetPIVData ParseData(ReadOnlySpan<byte> data)
         {
             if (data.Length < 5 || data.Length > 6)
@@ -101,8 +104,15 @@ namespace OSDP.Net.Model.CommandData
             return data.ToArray();
         }
 
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
-        public string ToString(int indent = 0)
+
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             var padding = new string(' ', indent);
             var build = new StringBuilder();

--- a/src/OSDP.Net/Model/CommandData/ManufacturerSpecific.cs
+++ b/src/OSDP.Net/Model/CommandData/ManufacturerSpecific.cs
@@ -36,6 +36,9 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public byte[] Data { get; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of ManufacturerSpecific representing the message payload</returns>
         public static ManufacturerSpecific ParseData(ReadOnlySpan<byte> data)
         {
             return new ManufacturerSpecific(
@@ -44,6 +47,10 @@ namespace OSDP.Net.Model.CommandData
             );
         }
 
+        /// <summary>
+        /// Builds the data.
+        /// </summary>
+        /// <returns>The Data</returns>
         public IEnumerable<byte> BuildData()
         {
             var data = new List<byte>
@@ -56,8 +63,15 @@ namespace OSDP.Net.Model.CommandData
             return data;
         }
 
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
-        public string ToString(int indent = 0)
+
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             var padding = new string(' ', indent);
             var build = new StringBuilder();

--- a/src/OSDP.Net/Model/CommandData/ManufacturerSpecific.cs
+++ b/src/OSDP.Net/Model/CommandData/ManufacturerSpecific.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 
 namespace OSDP.Net.Model.CommandData
 {
@@ -34,7 +36,15 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public byte[] Data { get; }
 
-        internal IEnumerable<byte> BuildData()
+        public static ManufacturerSpecific ParseData(ReadOnlySpan<byte> data)
+        {
+            return new ManufacturerSpecific(
+                data.Slice(0, 3).ToArray(),
+                data.Slice(3).ToArray()
+            );
+        }
+
+        public IEnumerable<byte> BuildData()
         {
             var data = new List<byte>
             {
@@ -44,6 +54,16 @@ namespace OSDP.Net.Model.CommandData
             };
             data.AddRange(Data);
             return data;
+        }
+
+        public override string ToString() => ToString(0);
+        public string ToString(int indent = 0)
+        {
+            var padding = new string(' ', indent);
+            var build = new StringBuilder();
+            build.AppendLine($"{padding}Vendor Code: {BitConverter.ToString(VendorCode.ToArray())}");
+            build.AppendLine($"{padding}       Data: {BitConverter.ToString(Data.ToArray())}");
+            return build.ToString();
         }
     }
 }

--- a/src/OSDP.Net/Model/CommandData/OutputControl.cs
+++ b/src/OSDP.Net/Model/CommandData/OutputControl.cs
@@ -38,6 +38,9 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public ushort Timer { get; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of OutputControl representing the message payload</returns>
         public static OutputControl ParseData(ReadOnlySpan<byte> data)
         {
             return new OutputControl(
@@ -45,6 +48,10 @@ namespace OSDP.Net.Model.CommandData
                 Message.ConvertBytesToUnsignedShort(data.Slice(2)));
         }
 
+        /// <summary>
+        /// Builds the data.
+        /// </summary>
+        /// <returns>The Data</returns>
         public IEnumerable<byte> BuildData()
         {
             var timerBytes = Message.ConvertShortToBytes(Timer);
@@ -52,8 +59,15 @@ namespace OSDP.Net.Model.CommandData
             return new[] {OutputNumber, (byte) OutputControlCode, timerBytes[0], timerBytes[1]};
         }
 
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
-        public string ToString(int indent=4)
+
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             var padding = new string(' ', indent);
             var sb = new StringBuilder();

--- a/src/OSDP.Net/Model/CommandData/OutputControl.cs
+++ b/src/OSDP.Net/Model/CommandData/OutputControl.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Collections.Generic;
+using System.Text;
 using OSDP.Net.Messages;
 
 namespace OSDP.Net.Model.CommandData
@@ -36,11 +38,29 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public ushort Timer { get; }
 
-        internal IEnumerable<byte> BuildData()
+        public static OutputControl ParseData(ReadOnlySpan<byte> data)
+        {
+            return new OutputControl(
+                data[0], (OutputControlCode)data[1],
+                Message.ConvertBytesToUnsignedShort(data.Slice(2)));
+        }
+
+        public IEnumerable<byte> BuildData()
         {
             var timerBytes = Message.ConvertShortToBytes(Timer);
             
             return new[] {OutputNumber, (byte) OutputControlCode, timerBytes[0], timerBytes[1]};
+        }
+
+        public override string ToString() => ToString(0);
+        public string ToString(int indent=4)
+        {
+            var padding = new string(' ', indent);
+            var sb = new StringBuilder();
+            sb.AppendLine($"{padding} Output #: {OutputNumber}");
+            sb.AppendLine($"{padding}Ctrl Code: {OutputControlCode}");
+            sb.AppendLine($"{padding}    Timer: {Timer}");
+            return sb.ToString();
         }
     }
 }

--- a/src/OSDP.Net/Model/CommandData/ReaderBuzzerControl.cs
+++ b/src/OSDP.Net/Model/CommandData/ReaderBuzzerControl.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text;
 
 namespace OSDP.Net.Model.CommandData
 {
@@ -50,9 +51,28 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public byte Count { get;  }
 
-        internal IEnumerable<byte> BuildData()
+        public static ReaderBuzzerControl ParseData(ReadOnlySpan<byte> data)
+        {
+            return new ReaderBuzzerControl(data[0], (ToneCode)data[1], data[2], data[3], data[4]);
+        }
+
+        public IEnumerable<byte> BuildData()
         {
             return new[] {ReaderNumber, (byte) ToneCode, OnTime, OffTime, Count};
+        }
+
+        public override string ToString() => ToString(0);
+
+        public string ToString(int indent = 0)
+        {
+            var padding = new string(' ', indent);
+            var sb = new StringBuilder();
+            sb.AppendLine($"{padding} Reader #: {ReaderNumber}");
+            sb.AppendLine($"{padding}Tone Code: {ToneCode}");
+            sb.AppendLine($"{padding}  On Time: {OnTime}");
+            sb.AppendLine($"{padding} Off Time: {OffTime}");
+            sb.AppendLine($"{padding}    Count: {Count}");
+            return sb.ToString();
         }
     }
 

--- a/src/OSDP.Net/Model/CommandData/ReaderBuzzerControl.cs
+++ b/src/OSDP.Net/Model/CommandData/ReaderBuzzerControl.cs
@@ -51,19 +51,32 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public byte Count { get;  }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of ReaderBuzzerControl representing the message payload</returns>
         public static ReaderBuzzerControl ParseData(ReadOnlySpan<byte> data)
         {
             return new ReaderBuzzerControl(data[0], (ToneCode)data[1], data[2], data[3], data[4]);
         }
 
+        /// <summary>
+        /// Builds the data.
+        /// </summary>
+        /// <returns>The Data</returns>
         public IEnumerable<byte> BuildData()
         {
             return new[] {ReaderNumber, (byte) ToneCode, OnTime, OffTime, Count};
         }
 
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
 
-        public string ToString(int indent = 0)
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             var padding = new string(' ', indent);
             var sb = new StringBuilder();

--- a/src/OSDP.Net/Model/CommandData/ReaderTextOutput.cs
+++ b/src/OSDP.Net/Model/CommandData/ReaderTextOutput.cs
@@ -54,12 +54,34 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public string Text { get; }
 
-        internal IEnumerable<byte> BuildData()
+        public static ReaderTextOutput ParseData(ReadOnlySpan<byte> data)
+        {
+            string text = Encoding.ASCII.GetString(data.Slice(6).ToArray());
+            return new ReaderTextOutput(data[0], (TextCommand)data[1], data[2], data[3], data[4], text);
+        }
+
+        public IEnumerable<byte> BuildData()
         {
             var data = new List<byte>
                 {ReaderNumber, (byte) TextCommand, TemporaryTextTime, Row, Column, (byte) Text.Length};
             data.AddRange(Encoding.ASCII.GetBytes(Text.Substring(0, Math.Min(Text.Length, byte.MaxValue))));
             return data;
+        }
+
+        public override string ToString() => ToString(0);
+
+        public string ToString(int indent=4)
+        {
+            string padding = new string(' ', indent);
+
+            var build = new StringBuilder();
+            build.AppendLine($"{padding}Reader Number: {ReaderNumber}");
+            build.AppendLine($"{padding}  Text Command: {TextCommand}");
+            build.AppendLine($"{padding}Temp Text Time: {TemporaryTextTime}");
+            build.AppendLine($"{padding}   Row, Column: {Row}, {Column}");
+            build.AppendLine($"{padding}  Display Text: {Text}");
+
+            return build.ToString();
         }
     }
 

--- a/src/OSDP.Net/Model/CommandData/ReaderTextOutput.cs
+++ b/src/OSDP.Net/Model/CommandData/ReaderTextOutput.cs
@@ -54,12 +54,19 @@ namespace OSDP.Net.Model.CommandData
         /// </summary>
         public string Text { get; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of ReaderTextOutput representing the message payload</returns>
         public static ReaderTextOutput ParseData(ReadOnlySpan<byte> data)
         {
             string text = Encoding.ASCII.GetString(data.Slice(6).ToArray());
             return new ReaderTextOutput(data[0], (TextCommand)data[1], data[2], data[3], data[4], text);
         }
 
+        /// <summary>
+        /// Builds the data.
+        /// </summary>
+        /// <returns>The Data</returns>
         public IEnumerable<byte> BuildData()
         {
             var data = new List<byte>
@@ -68,9 +75,15 @@ namespace OSDP.Net.Model.CommandData
             return data;
         }
 
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
 
-        public string ToString(int indent=4)
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             string padding = new string(' ', indent);
 

--- a/src/OSDP.Net/Model/PayloadData.cs
+++ b/src/OSDP.Net/Model/PayloadData.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OSDP.Net.Model
+{
+    /// <summary>
+    /// Base class representing a paylod an OSDP message
+    /// </summary>
+    public abstract class PayloadData
+    {
+        /// <summary>
+        /// Converts the payload into a byte array to be sent over the wire. The design
+        /// decision to put the burden of adding padding on every deriving class is intentional
+        /// as this method is where byte[] array originates and creating a payload that is
+        /// ready to be encoded, helps us avoid a few downstream heap operations.
+        /// </summary>
+        /// <param name="withPadding">Indicates if returned packed data should be padded
+        /// to a 16-byte boundary such that it is ready to be encrypted</param>
+        /// <returns>Packed reply as array of raw bytes. Note that some types of replies,
+        /// like osdp_ACK do not have additional data, in which case it is perfectly
+        /// acceptable for this array to be 0 length</returns>
+        public abstract byte[] BuildData(bool withPadding = false);
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            try
+            {
+                return ToString(0);
+            }
+            catch (NotImplementedException)
+            {
+                return base.ToString();
+            }
+        }
+
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public virtual string ToString(int indent)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/OSDP.Net/Model/PayloadData.cs
+++ b/src/OSDP.Net/Model/PayloadData.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OSDP.Net.Model
 {

--- a/src/OSDP.Net/Model/ReplyData/ChallengeResponse.cs
+++ b/src/OSDP.Net/Model/ReplyData/ChallengeResponse.cs
@@ -22,10 +22,24 @@ namespace OSDP.Net.Model.ReplyData
             Cryptogram = cryptogram;
         }
 
+        /// <summary>
+        /// Client Unique ID
+        /// </summary>
         public byte[] ClientUID {get; private set;}
+
+        /// <summary>
+        /// Rnd.B as defined in OSDP.NET spec
+        /// </summary>
         public byte[] RndB { get; private set; }
+
+        /// <summary>
+        /// Client (PD-side) cryptogram as defined in OSDP.NET spec
+        /// </summary>
         public byte[] Cryptogram { get; private set; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of ChallengeResponse representing the message payload</returns>
         public static ChallengeResponse ParseData(ReadOnlySpan<byte> data)
         {
             if (data.Length != 32)

--- a/src/OSDP.Net/Model/ReplyData/CommunicationConfiguration.cs
+++ b/src/OSDP.Net/Model/ReplyData/CommunicationConfiguration.cs
@@ -24,6 +24,9 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public int BaudRate { get; private set; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of CommunicationConfiguration representing the message payload</returns>
         internal static CommunicationConfiguration ParseData(ReadOnlySpan<byte> data)
         {
             var dataArray = data.ToArray();

--- a/src/OSDP.Net/Model/ReplyData/DataFragmentResponse.cs
+++ b/src/OSDP.Net/Model/ReplyData/DataFragmentResponse.cs
@@ -8,7 +8,7 @@ namespace OSDP.Net.Model.ReplyData
     /// <summary>
     /// A multi-part message data fragment reply.
     /// </summary>
-    internal class DataFragmentResponse
+    public class DataFragmentResponse
     {
         private DataFragmentResponse()
         {
@@ -34,7 +34,7 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public byte[] Data { get; private set; }
 
-        internal static DataFragmentResponse ParseData(ReadOnlySpan<byte> data)
+        public static DataFragmentResponse ParseData(ReadOnlySpan<byte> data)
         {
             if (data.Length < 6)
             {
@@ -54,13 +54,15 @@ namespace OSDP.Net.Model.ReplyData
         }
 
         /// <inheritdoc />
-        public override string ToString()
+        public override string ToString() => ToString(0);
+        public string ToString(int indent = 0)
         {
+            var padding = new string(' ', indent);
             var build = new StringBuilder();
-            build.AppendLine($"Whole Message Length: {WholeMessageLength}");
-            build.AppendLine($"              Offset: {Offset}");
-            build.AppendLine($"  Length of Fragment: {LengthOfFragment}");
-            build.AppendLine($"                Data: {BitConverter.ToString(Data.ToArray())}");
+            build.AppendLine($"{padding}Whole Message Length: {WholeMessageLength}");
+            build.AppendLine($"{padding}              Offset: {Offset}");
+            build.AppendLine($"{padding}  Length of Fragment: {LengthOfFragment}");
+            build.AppendLine($"{padding}                Data: {BitConverter.ToString(Data.ToArray())}");
             return build.ToString();
         }
     }

--- a/src/OSDP.Net/Model/ReplyData/DataFragmentResponse.cs
+++ b/src/OSDP.Net/Model/ReplyData/DataFragmentResponse.cs
@@ -34,6 +34,9 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public byte[] Data { get; private set; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of DataFragmentResponse representing the message payload</returns>
         public static DataFragmentResponse ParseData(ReadOnlySpan<byte> data)
         {
             if (data.Length < 6)
@@ -53,9 +56,15 @@ namespace OSDP.Net.Model.ReplyData
             return fragmentResponse;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
-        public string ToString(int indent = 0)
+
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             var padding = new string(' ', indent);
             var build = new StringBuilder();

--- a/src/OSDP.Net/Model/ReplyData/DeviceCapabilities.cs
+++ b/src/OSDP.Net/Model/ReplyData/DeviceCapabilities.cs
@@ -42,6 +42,9 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public T Get<T>(CapabilityFunction funcCode) where T : DeviceCapability => (T)Get(funcCode);
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of DeviceCapabilities representing the message payload</returns>
         internal static DeviceCapabilities ParseData(ReadOnlySpan<byte> data)
         {
             var dataArray = data.ToArray();

--- a/src/OSDP.Net/Model/ReplyData/DeviceIdentification.cs
+++ b/src/OSDP.Net/Model/ReplyData/DeviceIdentification.cs
@@ -48,7 +48,7 @@ namespace OSDP.Net.Model.ReplyData
         /// <inheritdoc/>
         public override ReplyType ReplyType => ReplyType.PdIdReport;
 
-        internal static DeviceIdentification ParseData(ReadOnlySpan<byte> data)
+        public static DeviceIdentification ParseData(ReadOnlySpan<byte> data)
         {
             var dataArray = data.ToArray();
             if (dataArray.Length != 12)
@@ -88,14 +88,18 @@ namespace OSDP.Net.Model.ReplyData
         }
 
         /// <inheritdoc />
-        public override string ToString()
+        public override string ToString() => ToString(0);
+
+        public string ToString(int indent = 4)
         {
+            string padding = new string(' ', indent);
+
             var build = new StringBuilder();
-            build.AppendLine($"     Vendor Code: {BitConverter.ToString(VendorCode.ToArray())}");
-            build.AppendLine($"    Model Number: {ModelNumber}");
-            build.AppendLine($"         Version: {Version}");
-            build.AppendLine($"   Serial Number: {BitConverter.ToString(Message.ConvertIntToBytes(SerialNumber).ToArray())}");
-            build.AppendLine($"Firmware Version: {FirmwareMajor}.{FirmwareMinor}.{FirmwareBuild}");
+            build.AppendLine($"{padding}     Vendor Code: {BitConverter.ToString(VendorCode.ToArray())}");
+            build.AppendLine($"{padding}    Model Number: {ModelNumber}");
+            build.AppendLine($"{padding}         Version: {Version}");
+            build.AppendLine($"{padding}   Serial Number: {BitConverter.ToString(Message.ConvertIntToBytes(SerialNumber).ToArray())}");
+            build.AppendLine($"{padding}Firmware Version: {FirmwareMajor}.{FirmwareMinor}.{FirmwareBuild}");
 
             return build.ToString();
         }

--- a/src/OSDP.Net/Model/ReplyData/DeviceIdentification.cs
+++ b/src/OSDP.Net/Model/ReplyData/DeviceIdentification.cs
@@ -48,6 +48,9 @@ namespace OSDP.Net.Model.ReplyData
         /// <inheritdoc/>
         public override ReplyType ReplyType => ReplyType.PdIdReport;
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of DeviceIdentification representing the message payload</returns>
         public static DeviceIdentification ParseData(ReadOnlySpan<byte> data)
         {
             var dataArray = data.ToArray();
@@ -87,10 +90,8 @@ namespace OSDP.Net.Model.ReplyData
             return buffer;
         }
 
-        /// <inheritdoc />
-        public override string ToString() => ToString(0);
-
-        public string ToString(int indent = 4)
+        /// <inheritdoc/>
+        public override string ToString(int indent)
         {
             string padding = new string(' ', indent);
 

--- a/src/OSDP.Net/Model/ReplyData/FileTransferStatus.cs
+++ b/src/OSDP.Net/Model/ReplyData/FileTransferStatus.cs
@@ -83,6 +83,9 @@ namespace OSDP.Net.Model.ReplyData
         /// <summary>Gets the alternative maximum message size.</summary>
         public ushort UpdateMessageMaximum { get; private set; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of FileTransferStatus representing the message payload</returns>
         internal static FileTransferStatus ParseData(ReadOnlySpan<byte> data)
         {
             var dataArray = data.ToArray();

--- a/src/OSDP.Net/Model/ReplyData/KeypadData.cs
+++ b/src/OSDP.Net/Model/ReplyData/KeypadData.cs
@@ -64,6 +64,9 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public byte[] Data { get; private set; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of KeypadData representing the message payload</returns>
         public static KeypadData ParseData(ReadOnlySpan<byte> data)
         {
             if (data.Length < DataStartIndex)
@@ -81,9 +84,15 @@ namespace OSDP.Net.Model.ReplyData
             return keypadReplyData;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
-        public string ToString(int indent = 0)
+
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             var padding = new string(' ', indent);
             var build = new StringBuilder();

--- a/src/OSDP.Net/Model/ReplyData/KeypadData.cs
+++ b/src/OSDP.Net/Model/ReplyData/KeypadData.cs
@@ -64,7 +64,7 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public byte[] Data { get; private set; }
 
-        internal static KeypadData ParseData(ReadOnlySpan<byte> data)
+        public static KeypadData ParseData(ReadOnlySpan<byte> data)
         {
             if (data.Length < DataStartIndex)
             {
@@ -82,12 +82,14 @@ namespace OSDP.Net.Model.ReplyData
         }
 
         /// <inheritdoc />
-        public override string ToString()
+        public override string ToString() => ToString(0);
+        public string ToString(int indent = 0)
         {
+            var padding = new string(' ', indent);
             var build = new StringBuilder();
-            build.AppendLine($"Reader Number: {ReaderNumber}");
-            build.AppendLine($"  Digit Count: {DigitCount}");
-            build.AppendLine($"         Data: {DetermineCharacters(Data, DigitCount)}");
+            build.AppendLine($"{padding}Reader Number: {ReaderNumber}");
+            build.AppendLine($"{padding}  Digit Count: {DigitCount}");
+            build.AppendLine($"{padding}         Data: {DetermineCharacters(Data, DigitCount)}");
             return build.ToString();
         }
 

--- a/src/OSDP.Net/Model/ReplyData/ManufacturerSpecific.cs
+++ b/src/OSDP.Net/Model/ReplyData/ManufacturerSpecific.cs
@@ -27,6 +27,9 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public IEnumerable<byte> Data { get; private set; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of ManufacturerSpecific representing the message payload</returns>
         public static ManufacturerSpecific ParseData(ReadOnlySpan<byte> data)
         {
             var dataArray = data.ToArray();
@@ -44,9 +47,15 @@ namespace OSDP.Net.Model.ReplyData
             return manufacturerSpecificReply;
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
-        public string ToString(int indent = 0)
+
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             var padding = new string(' ', indent);
             var build = new StringBuilder();

--- a/src/OSDP.Net/Model/ReplyData/ManufacturerSpecific.cs
+++ b/src/OSDP.Net/Model/ReplyData/ManufacturerSpecific.cs
@@ -27,7 +27,7 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public IEnumerable<byte> Data { get; private set; }
 
-        internal static ManufacturerSpecific ParseData(ReadOnlySpan<byte> data)
+        public static ManufacturerSpecific ParseData(ReadOnlySpan<byte> data)
         {
             var dataArray = data.ToArray();
             if (dataArray.Length < 3)
@@ -45,11 +45,13 @@ namespace OSDP.Net.Model.ReplyData
         }
 
         /// <inheritdoc />
-        public override string ToString()
+        public override string ToString() => ToString(0);
+        public string ToString(int indent = 0)
         {
+            var padding = new string(' ', indent);
             var build = new StringBuilder();
-            build.AppendLine($"Vendor Code: {BitConverter.ToString(VendorCode.ToArray())}");
-            build.AppendLine($"       Data: {BitConverter.ToString(Data.ToArray())}");
+            build.AppendLine($"{padding}Vendor Code: {BitConverter.ToString(VendorCode.ToArray())}");
+            build.AppendLine($"{padding}       Data: {BitConverter.ToString(Data.ToArray())}");
             return build.ToString();
         }
     }

--- a/src/OSDP.Net/Model/ReplyData/OutputStatus.cs
+++ b/src/OSDP.Net/Model/ReplyData/OutputStatus.cs
@@ -22,14 +22,23 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public IEnumerable<bool> OutputStatuses { get; private set; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of OutputStatus representing the message payload</returns>
         public static OutputStatus ParseData(ReadOnlySpan<byte> data)
         {
             return new OutputStatus {OutputStatuses = data.ToArray().Select(Convert.ToBoolean)};
         }
 
-        /// <inheritdoc />
+        /// <inheritdoc/>
         public override string ToString() => ToString(0);
-        public string ToString(int indent = 0)
+
+        /// <summary>
+        /// Returns a string representation of the current object
+        /// </summary>
+        /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
+        /// <returns>String representation of the current object</returns>
+        public string ToString(int indent)
         {
             var padding = new string(' ', indent);
             byte outputNumber = 0;

--- a/src/OSDP.Net/Model/ReplyData/OutputStatus.cs
+++ b/src/OSDP.Net/Model/ReplyData/OutputStatus.cs
@@ -22,21 +22,22 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public IEnumerable<bool> OutputStatuses { get; private set; }
 
-        internal static OutputStatus ParseData(ReadOnlySpan<byte> data)
+        public static OutputStatus ParseData(ReadOnlySpan<byte> data)
         {
             return new OutputStatus {OutputStatuses = data.ToArray().Select(Convert.ToBoolean)};
         }
 
         /// <inheritdoc />
-        public override string ToString()
+        public override string ToString() => ToString(0);
+        public string ToString(int indent = 0)
         {
+            var padding = new string(' ', indent);
             byte outputNumber = 0;
             var build = new StringBuilder();
             foreach (bool outputStatus in OutputStatuses)
             {
-                build.AppendLine($"Output Number {outputNumber++:00}: {outputStatus}");
+                build.AppendLine($"{padding}Output Number {outputNumber++:00}: {outputStatus}");
             }
-
             return build.ToString();
         }
     }

--- a/src/OSDP.Net/Model/ReplyData/RawCardData.cs
+++ b/src/OSDP.Net/Model/ReplyData/RawCardData.cs
@@ -60,7 +60,7 @@ namespace OSDP.Net.Model.ReplyData
         /// <param name="data">The data.</param>
         /// <returns>RawCardData.</returns>
         /// <exception cref="System.Exception">Invalid size for the data</exception>
-        internal static RawCardData ParseData(ReadOnlySpan<byte> data)
+        public static RawCardData ParseData(ReadOnlySpan<byte> data)
         {
             var dataArray = data.ToArray();
             if (dataArray.Length < 4)
@@ -85,13 +85,15 @@ namespace OSDP.Net.Model.ReplyData
         }
 
         /// <inheritdoc />
-        public override string ToString()
+        public override string ToString() => ToString(0);
+        public string ToString(int indent = 0)
         {
+            var padding = new string(' ', indent);
             var build = new StringBuilder();
-            build.AppendLine($"Reader Number: {ReaderNumber}");
-            build.AppendLine($"  Format Code: {Helpers.SplitCamelCase(FormatCode.ToString())}");
-            build.AppendLine($"    Bit Count: {BitCount}");
-            build.AppendLine($"         Data: {FormatData(Data)}");
+            build.AppendLine($"{padding}Reader Number: {ReaderNumber}");
+            build.AppendLine($"{padding}  Format Code: {Helpers.SplitCamelCase(FormatCode.ToString())}");
+            build.AppendLine($"{padding}    Bit Count: {BitCount}");
+            build.AppendLine($"{padding}         Data: {FormatData(Data)}");
             return build.ToString();
         }
 

--- a/src/OSDP.Net/Model/ReplyData/RawCardData.cs
+++ b/src/OSDP.Net/Model/ReplyData/RawCardData.cs
@@ -84,9 +84,8 @@ namespace OSDP.Net.Model.ReplyData
             return rawCardData;
         }
 
-        /// <inheritdoc />
-        public override string ToString() => ToString(0);
-        public string ToString(int indent = 0)
+        /// <inheritdoc/>
+        public override string ToString(int indent)
         {
             var padding = new string(' ', indent);
             var build = new StringBuilder();

--- a/src/OSDP.Net/Model/ReplyData/ReaderStatus.cs
+++ b/src/OSDP.Net/Model/ReplyData/ReaderStatus.cs
@@ -20,6 +20,9 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public IEnumerable<ReaderTamperStatus> ReaderTamperStatuses { get; private set; }
 
+        /// <summary>Parses the message payload bytes</summary>
+        /// <param name="data">Message payload as bytes</param>
+        /// <returns>An instance of ReaderStatus representing the message payload</returns>
         internal static ReaderStatus ParseData(ReadOnlySpan<byte> data)
         {
             return new ReaderStatus

--- a/src/OSDP.Net/Model/ReplyData/ReplyData.cs
+++ b/src/OSDP.Net/Model/ReplyData/ReplyData.cs
@@ -5,21 +5,8 @@ namespace OSDP.Net.Model.ReplyData
     /// <summary>
     /// Base class representing a paylod of a PD reply message
     /// </summary>
-    public abstract class ReplyData
+    public abstract class ReplyData : PayloadData
     {
-        /// <summary>
-        /// Converts the reply into a byte array to be sent to ACU over the wire. The design
-        /// decision to put the burden of adding padding on every deriving class is intentional
-        /// as this method is where byte[] array originates and creating a payload that is
-        /// ready to be encoded, helps us avoid a few downstream heap operations.
-        /// </summary>
-        /// <param name="withPadding">Indicates if returned packed data should be padded
-        /// to a 16-byte boundary such that it is ready to be encrypted</param>
-        /// <returns>Packed reply as array of raw bytes. Note that some types of replies,
-        /// like osdp_ACK do not have additional data, in which case it is perfectly
-        /// acceptable for this array to be 0 length</returns>
-        public abstract byte[] BuildData(bool withPadding = false);
-
         /// <summary>
         /// Message reply code
         /// </summary>

--- a/src/OSDP.Net/SecureChannel2.cs
+++ b/src/OSDP.Net/SecureChannel2.cs
@@ -1,0 +1,430 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using Microsoft.Extensions.Logging;
+using OSDP.Net.Messages;
+using OSDP.Net.Messages.PD;
+using OSDP.Net.Model.ReplyData;
+
+namespace OSDP.Net
+{
+    /// <summary>
+    /// V2 implementation of a SecureChannel class.
+    /// 
+    /// With introduction of OSDP PD simulator as well as CLI tool to parse pcap files generated 
+    /// by this library, we had to do some refactoring. In doing so, we introduced a new Message class
+    /// hierarchy based on Message -> IncomingMessage inheritance  (we are yet to add OutgoingMessage
+    /// but most of the logic that would go in that, is presently in OSDP.NET.Messages.PD.Reply class)
+    /// 
+    /// Whereas the older SecureChannel class was passed directly into Message parsing/building code,
+    /// this new class hierarchy depends on IMessageChannel interface to interact with the secure
+    /// channel context and this class is the base implementation for that
+    /// </summary>
+    public abstract class MessageChannel : IMessageChannel
+    {
+        /// <summary>
+        /// Optional logger instance
+        /// </summary>
+        protected readonly ILogger _logger;
+
+        /// <summary>
+        /// Initializes a new instance of SecurityChannel2 class
+        /// </summary>
+        /// <param name="context">Optional security context state to be used by the channel. If one 
+        /// is not provided, new default instance of the context will be created internally. This is
+        /// useful when more than one channel have a need to share the same security state (i.e. in
+        /// cases of implementing a spy that analyzes traffic flow through the two inbound and outbound
+        /// channels</param>
+        /// <param name="loggerFactory">Optional logger factory from which a logger object for the
+        /// message channel will be acquired</param>
+        public MessageChannel(SecurityContext context = null, ILoggerFactory loggerFactory = null)
+        {
+            Context = context ?? new();
+            _logger = loggerFactory?.CreateLogger(GetType());
+        }
+
+        /// <summary>
+        /// Security state used by the channel
+        /// </summary>
+        protected SecurityContext Context { get; private set; }
+
+        /// <inheritdoc/>
+        public bool IsSecurityEstablished => Context.IsSecurityEstablished;
+
+        /// <inheritdoc/>
+        public abstract byte[] DecodePayload(byte[] payload);
+
+        /// <inheritdoc/>
+        public abstract void EncodePayload(byte[] payload, Span<byte> destination);
+
+        /// <inheritdoc/>
+        public abstract ReadOnlySpan<byte> GenerateMac(ReadOnlySpan<byte> message, bool isIncoming);
+
+        /// <summary>
+        /// Generates a MAC for a command message
+        /// </summary>
+        /// <param name="message">Message bytes to generate code from</param>
+        /// <returns>Newly generated MAC</returns>
+        /// <exception cref="SecureChannelRequired">Thrown if secure channel has not been established</exception>
+        protected byte[] GenerateCommandMac(ReadOnlySpan<byte> message) => (Context.CMac = GenerateMac(message, Context.RMac));
+
+        /// <summary>
+        /// Generates a MAC for a reply message
+        /// </summary>
+        /// <param name="message">Message bytes to generate code from</param>
+        /// <returns>Newly generated MAC</returns>
+        /// <exception cref="SecureChannelRequired">Thrown if secure channel has not been established</exception>
+        protected byte[] GenerateReplyMac(ReadOnlySpan<byte> message) => (Context.RMac = GenerateMac(message, Context.CMac));
+
+        private byte[] GenerateMac(ReadOnlySpan<byte> message, byte[] IV)
+        {
+            if (!IsSecurityEstablished)
+            {
+                throw new SecureChannelRequired();
+            }
+
+            using var crypto = SecurityContext.CreateCypher(Context.SMac1, false);
+            crypto.IV = IV;
+
+            var initialVector = crypto.IV;
+
+            var cursor = message;
+            while (cursor.Length > 0)
+            {
+                byte[] block;
+
+                if (cursor.Length < 16)
+                {
+                    block = new byte[16];
+                    cursor.CopyTo(block);
+                    block[cursor.Length] = Message.FirstPaddingByte;
+                    cursor = cursor.Slice(cursor.Length);
+                    crypto.Key = Context.SMac2;
+                }
+                else
+                {
+                    block = cursor.Slice(0, 16).ToArray();
+                    cursor = cursor.Slice(16);
+                    if (cursor.Length == 0) crypto.Key = Context.SMac2;
+                }
+
+                using var encryptor = crypto.CreateEncryptor();
+                crypto.IV = encryptor.TransformFinalBlock(block, 0, block.Length);
+            }
+
+            return crypto.IV;
+        }
+
+
+
+        /// <summary>
+        /// Decodes the payload
+        /// </summary>
+        /// <param name="payload">Cyphertext of the message payload</param>
+        /// <param name="IV">crypto initialization vector</param>
+        /// <returns>Message payload as plaintext</returns>
+        protected byte[] DecodePayload(byte[] payload, byte[] IV)
+        {
+            if (!IsSecurityEstablished)
+            {
+                throw new SecureChannelRequired();
+            }
+            else if (payload.Length == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            if (payload.Length % 16 != 0)
+            {
+                throw new Exception($"Unexpected payload length: {payload.Length}");
+            }
+
+            using var crypto = SecurityContext.CreateCypher(Context.Enc, false);
+            crypto.IV = IV.Select(b => (byte)~b).ToArray();
+
+            using var encryptor = crypto.CreateDecryptor();
+            return encryptor.TransformFinalBlock(payload, 0, payload.Length);
+        }
+
+        /// <summary>
+        /// Encodes the payload
+        /// </summary>
+        /// <param name="payload">Message payload as plaintext</param>
+        /// <param name="IV">Crypto initialization vector</param>
+        /// <param name="destination">Destination where cyphertext is to be written</param>
+        /// <returns>Cyphertext of the message payload</returns>
+        protected void EncodePayload(byte[] payload, byte[] IV, Span<byte> destination)
+        {
+            if (!IsSecurityEstablished)
+            {
+                throw new SecureChannelRequired();
+            }
+            else if (payload.Length > 0)
+            {
+                if (payload.Length % 16 != 0)
+                {
+                    throw new Exception($"Unexpected payload length: {payload.Length}");
+                }
+
+                using var crypto = SecurityContext.CreateCypher(Context.Enc, false);
+                crypto.IV = IV.Select(b => (byte)~b).ToArray();
+
+                using var encryptor = crypto.CreateEncryptor();
+                encryptor.TransformFinalBlock(payload, 0, payload.Length).CopyTo(destination);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Message channel which represents the Periphery Device (PD) side of the OSDP 
+    /// communications (i.e. OSDP commands are received and replies are sent out)
+    /// </summary>
+    public class PDMessageChannel : MessageChannel
+    {
+        private byte[] _expectedServerCryptogram;
+
+        /// <summary>
+        /// Initializes a new instance of the PDMessageChannel
+        /// </summary>
+        /// <param name="context">Optional security context state to be used by the channel. If one 
+        /// is not provided, new default instance of the context will be created internally. This is
+        /// useful when more than one channel have a need to share the same security state (i.e. in
+        /// cases of implementing a spy that analyzes traffic flow through the two inbound and outbound
+        /// channels</param>
+        /// <param name="loggerFactory">Optional logger factory from which a logger object for the
+        /// message channel will be acquired</param>
+        public PDMessageChannel(SecurityContext context = null, ILoggerFactory loggerFactory = null) 
+            : base(context, loggerFactory) {}
+
+        /// <inheritdoc />
+        public override void EncodePayload(byte[] payload, Span<byte> destination) =>
+            EncodePayload(payload, Context.CMac, destination);
+
+        /// <inheritdoc />
+        public override byte[] DecodePayload(byte[] payload) => DecodePayload(payload, Context.RMac);
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<byte> GenerateMac(ReadOnlySpan<byte> message, bool isIncoming) =>
+            isIncoming ? GenerateCommandMac(message) : GenerateReplyMac(message);
+
+        /// <summary>
+        /// Default handler for the SessionChallenge message received on the channel
+        /// </summary>
+        /// <param name="command">Incoming command of type SessionChallenge</param>
+        /// <returns>A message representing a reply to the SessionChallenge</returns>
+        protected Reply HandleSessionChallenge(IncomingMessage command)
+        {
+            // TODO: this should be some kind of unique identifier, but a) not sure how to generate it and b) seems
+            // the other side presently simply ignores these bytes. So for time being simply leaving this uninitialized
+            byte[] cUID = new byte[8];
+
+            byte[] rndA = command.Payload;
+            byte[] rndB = new byte[8];
+
+            // TODO: Although somewhere we do need to store the default key, this must not be 
+            // just permanently hardcoded for all sessions. For now this code is only used in the
+            // simulator so this is okay, but it is definitely a candidate for next set of enhancements
+#pragma warning disable IDE0230 // Use UTF-8 string literal
+            byte[] secureChannelKey = new byte[] {
+                0x30, 0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38, 0x39, 0x3a, 0x3b, 0x3c, 0x3d, 0x3e, 0x3f };
+#pragma warning restore IDE0230 // Use UTF-8 string literal
+
+            // TODO: we should validate payload and SCB type
+
+            // It is possible that ACU may decide to re-challenge us after a channel was already set up.
+            // In that case, let's make sure we clear this flag to indicate that we do NOT in fact have security
+            // established
+            Context.IsSecurityEstablished = false;
+
+            // generate RND.B
+            new Random().NextBytes(rndB);
+
+            // generate a set of sessioon keys: S-ENC, S-MAC1, S-MAC2 using command.Payload (which is RND.A)
+            var crypto = SecurityContext.CreateCypher(secureChannelKey, true);
+
+            Context.Enc = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x82, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
+            Context.SMac1 = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x01, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
+            Context.SMac2 = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x02, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
+
+            // generate client crytpogram
+            crypto.Key = Context.Enc;
+            var clientCryptogram = SecurityContext.GenerateKey(crypto, rndA, rndB);
+            _expectedServerCryptogram = SecurityContext.GenerateKey(crypto, rndB, rndA);
+
+            _logger?.LogInformation($"Rnd.A: {{rndA}}{Environment.NewLine}" +
+                $"Rnd.B: {{rndB}}{Environment.NewLine}" +
+                $"Enc: {{enc}}{Environment.NewLine}" +
+                $"ClientCrypto: {{ccrypto}}{Environment.NewLine}",
+                BitConverter.ToString(rndA),
+                BitConverter.ToString(rndB),
+                BitConverter.ToString(Context.Enc),
+                BitConverter.ToString(clientCryptogram));
+
+            // reply with osdp_CCRYPT, returning PD's Id (cUID), its random number and the client cryptogram
+            return new Reply(command, new ChallengeResponse(cUID, rndB, clientCryptogram));
+        }
+
+        /// <summary>
+        /// Default handler to the SCrypt command received on the channel
+        /// </summary>
+        /// <param name="command">An incoming message representing SCrypt command</param>
+        /// <returns>Reply to the SCrypt command</returns>
+        protected Reply HandleSCrypt(IncomingMessage command)
+        {
+            var serverCryptogram = command.Payload;
+
+            if (command.SecurityBlockType != (byte)SecurityBlockType.SecureConnectionSequenceStep3)
+            {
+                _logger.LogWarning("Received unexpected security block type: {sbt}", command.SecurityBlockType);
+            }
+            else if (!serverCryptogram.SequenceEqual(_expectedServerCryptogram))
+            {
+                _logger.LogWarning("Received unexpected server cryptogram!");
+            }
+            else if (IsSecurityEstablished)
+            {
+                _logger.LogWarning("Secure channel already established. Why did we get another SCrypt??");
+            }
+            else
+            {
+                var crypto = SecurityContext.CreateCypher(Context.SMac1, true);
+                Context.RMac = SecurityContext.GenerateKey(crypto, serverCryptogram);
+                crypto.Key = Context.SMac2;
+                Context.RMac = SecurityContext.GenerateKey(crypto, Context.RMac);
+
+                return new Reply(command, new InitialRMac(Context.RMac));
+            }
+
+            return new Reply(command, new Nak(ErrorCode.DoesNotSupportSecurityBlock));
+        }
+    }
+
+    /// <summary>
+    /// Message channel which represents the Access Control Unit (ACU) side of the OSDP 
+    /// communications (i.e. OSDP commands are sent out and replies are received)
+    /// </summary>
+    public class ACUMessageChannel : MessageChannel
+    {
+        /// <summary>
+        /// Initializes a new instance of the ACUMessageChannel
+        /// </summary>
+        /// <param name="context">Optional security context state to be used by the channel. If one 
+        /// is not provided, new default instance of the context will be created internally. This is
+        /// useful when more than one channel have a need to share the same security state (i.e. in
+        /// cases of implementing a spy that analyzes traffic flow through the two inbound and outbound
+        /// channels</param>
+        /// <param name="loggerFactory">Optional logger factory from which a logger object for the
+        /// message channel will be acquired</param>
+        public ACUMessageChannel(SecurityContext context = null, ILoggerFactory loggerFactory = null)
+            : base(context, loggerFactory) {}
+
+        /// <inheritdoc />
+        public override void EncodePayload(byte[] payload, Span<byte> destination) =>
+            EncodePayload(payload, Context.RMac, destination);
+
+        /// <inheritdoc />
+        public override byte[] DecodePayload(byte[] payload) => DecodePayload(payload, Context.CMac);
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<byte> GenerateMac(ReadOnlySpan<byte> message, bool isIncoming) =>
+            isIncoming ? GenerateReplyMac(message) : GenerateCommandMac(message);
+    }
+
+    /// <summary>
+    /// Security context used within SecureChannel2
+    /// 
+    /// This state data is placed into its own class to facilitate use cases where multiple channels
+    /// (i.e. one for incoming packets; one for outgoing) have to share the same security state.
+    /// </summary>
+    public class SecurityContext
+    {
+        /// <summary>
+        /// A flag indicating whether or not channel security has been established
+        /// </summary>
+        public bool IsSecurityEstablished { get; set; }
+
+        /// <summary>
+        /// Symmertric message encryption key established by the secure channel handshake
+        /// </summary>
+        public byte[] Enc { get; set; } = Array.Empty<byte>();
+
+        /// <summary>
+        /// S-MAC1 value
+        /// </summary>
+        public byte[] SMac1 { get; set; } = Array.Empty<byte>();
+
+        /// <summary>
+        /// S-MAC2 value
+        /// </summary>
+        public byte[] SMac2 { get; set; } = Array.Empty<byte>();
+
+        /// <summary>
+        /// R-MAC value
+        /// </summary>
+        public byte[] RMac { get; set; } = Array.Empty<byte>();
+
+        /// <summary>
+        /// C-MAC value
+        /// </summary>
+        public byte[] CMac { get; set; } = Array.Empty<byte>();
+
+        /// <summary>
+        /// Creates a new instance of AES cypher
+        /// </summary>
+        /// <param name="key">Encryption key to be used</param>
+        /// <param name="isForSessionSetup">We use the cypher in two major use cases: 
+        /// session setup and message data encryption. Depending on the case, it has 
+        /// to be initialized slightly differently so this flag indicates which case 
+        /// is currently needed.</param>
+        /// <returns>Cypher instance</returns>
+        public static Aes CreateCypher(byte[] key, bool isForSessionSetup)
+        {
+            var crypto = Aes.Create();
+            if (crypto == null)
+            {
+                throw new Exception("Unable to create key algorithm");
+            }
+
+            if (!isForSessionSetup)
+            {
+                crypto.Mode = CipherMode.CBC;
+                crypto.Padding = PaddingMode.None;
+            }
+            else
+            {
+                crypto.Mode = CipherMode.ECB;
+                crypto.Padding = PaddingMode.Zeros;
+            }
+            crypto.KeySize = 128;
+            crypto.BlockSize = 128;
+            crypto.Key = key;
+
+            return crypto;
+        }
+
+        /// <summary>
+        /// Slightly specialized version of simple AES encryption that is 
+        /// intended specifically for generating keys used in OSDP secure channel
+        /// comms. 
+        /// </summary>
+        /// <param name="aes">AES crypto instance</param>
+        /// <param name="input">Set of bytes to be used as input to generate the 
+        /// resulting key. For convenience the caller might pass in more than one
+        /// byte array, but the total sum of all bytes MUST be less than or equal
+        /// to 16</param>
+        /// <returns></returns>
+        public static byte[] GenerateKey(Aes aes, params byte[][] input)
+        {
+            var buffer = new byte[16];
+            int currentSize = 0;
+            foreach (byte[] x in input)
+            {
+                x.CopyTo(buffer, currentSize);
+                currentSize += x.Length;
+            }
+            using var encryptor = aes.CreateEncryptor();
+
+            return encryptor.TransformFinalBlock(buffer, 0, buffer.Length);
+        }
+    }
+}

--- a/src/OSDP.Net/Utilities/Binary.cs
+++ b/src/OSDP.Net/Utilities/Binary.cs
@@ -42,6 +42,11 @@ namespace OSDP.Net.Utilities
 
             while (enumerator.MoveNext())
             {
+                if (enumerator.Current == '-')
+                {
+                    if (!enumerator.MoveNext()) throw new InvalidOperationException("Not a valid hex string");
+                }
+
                 var a = enumerator.Current.HexToInt();
                 if (!enumerator.MoveNext()) throw new InvalidOperationException("Not a valid hex string");
                 var b = enumerator.Current.HexToInt();


### PR DESCRIPTION
The main motivator for this PR is introduction of a pcap parser CLI tool which needed the ability to act as a man-in-the-middle and establish its own secure channel context based on combination of out-of-band supplied key as well as interception of initial secure channel handshake in order to establish the unique session encryption key so that all subsequent commands and replies could be decoded.

This commit introduces SecureChannel2.cs which is intended to someday(tm) replace the logic in SecureChannel. The new code is based around IMessageChannel interface which is currently consumed by IncomingMessage and OSDP.Net.Messages.Reply class.

Whereas original SecureChannel was intended solely for ACU side of the communications, this new implementation is fully bi-directional and can support everything original implementation did, but can also represent the PD side of the secure comms as well as be used on the side in applications like the pcap file sniffer.
