### PR TITLE
Refactor device class 2

### DIFF
--- a/src/OSDP.Net.sln
+++ b/src/OSDP.Net.sln
@@ -1,32 +1,32 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26124.0
+# Visual Studio Version 17
+VisualStudioVersion = 17.8.34408.163
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSDP.Net", "OSDP.Net\OSDP.Net.csproj", "{50AC5FD2-8C50-48E4-AC4E-4A275D0A879E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSDP.Net", "OSDP.Net\OSDP.Net.csproj", "{50AC5FD2-8C50-48E4-AC4E-4A275D0A879E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Console", "Console\Console.csproj", "{182D66E4-7909-4B18-AF01-BF0FE8B932BC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Console", "Console\Console.csproj", "{182D66E4-7909-4B18-AF01-BF0FE8B932BC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "OSDP.Net.Tests", "OSDP.Net.Tests\OSDP.Net.Tests.csproj", "{0018DA90-BBB2-491D-A6C3-086F21D7C29A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "OSDP.Net.Tests", "OSDP.Net.Tests\OSDP.Net.Tests.csproj", "{0018DA90-BBB2-491D-A6C3-086F21D7C29A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Settings", "Settings", "{5CE38FA4-377F-4C0D-A680-9CEA9A7CDBEE}"
-ProjectSection(SolutionItems) = preProject
-	..\azure-pipelines.yml = ..\azure-pipelines.yml
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		..\azure-pipelines.yml = ..\azure-pipelines.yml
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{B304A16C-CA32-4692-9AED-D8886CC9184C}"
-ProjectSection(SolutionItems) = preProject
-	..\README.md = ..\README.md
-	..\docs\supported_commands.md = ..\docs\supported_commands.md
-	..\docs\powershell.md = ..\docs\powershell.md
-	..\CODE_OF_CONDUCT.md = ..\CODE_OF_CONDUCT.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		..\CODE_OF_CONDUCT.md = ..\CODE_OF_CONDUCT.md
+		..\docs\powershell.md = ..\docs\powershell.md
+		..\README.md = ..\README.md
+		..\docs\supported_commands.md = ..\docs\supported_commands.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Samples", "Samples", "{A57B307A-A240-4F4F-A3A8-A078093B2809}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PivDataReader", "samples\PivDataReader\PivDataReader.csproj", "{AC0ADC7D-3A78-4937-80B0-F8AA3B7B17BD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PivDataReader", "samples\PivDataReader\PivDataReader.csproj", "{AC0ADC7D-3A78-4937-80B0-F8AA3B7B17BD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CardReader", "samples\CardReader\CardReader.csproj", "{B6E1FC35-3DEC-495F-8FD2-A0CB9C3B4C6A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CardReader", "samples\CardReader\CardReader.csproj", "{B6E1FC35-3DEC-495F-8FD2-A0CB9C3B4C6A}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -36,9 +36,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 		Release|x64 = Release|x64
 		Release|x86 = Release|x86
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{50AC5FD2-8C50-48E4-AC4E-4A275D0A879E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -102,8 +99,14 @@ Global
 		{B6E1FC35-3DEC-495F-8FD2-A0CB9C3B4C6A}.Release|x86.ActiveCfg = Release|Any CPU
 		{B6E1FC35-3DEC-495F-8FD2-A0CB9C3B4C6A}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{AC0ADC7D-3A78-4937-80B0-F8AA3B7B17BD} = {A57B307A-A240-4F4F-A3A8-A078093B2809}
 		{B6E1FC35-3DEC-495F-8FD2-A0CB9C3B4C6A} = {A57B307A-A240-4F4F-A3A8-A078093B2809}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {07D0756C-2DA8-4FA1-8A4A-1FA6BCFBEB46}
 	EndGlobalSection
 EndGlobal

--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -643,6 +643,7 @@ namespace OSDP.Net
             }
             catch
             {
+                // TODO: be more selective with exception types?
                 return 0;
             }
         }

--- a/src/OSDP.Net/Connections/TcpServerOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/TcpServerOsdpConnection.cs
@@ -54,7 +54,7 @@ namespace OSDP.Net.Connections
         {
             var tcpClient = _tcpClient;
             _tcpClient = null;
-            if (_tcpClient?.Connected ?? false) tcpClient?.GetStream().Close();
+            if (tcpClient?.Connected ?? false) tcpClient?.GetStream().Close();
             tcpClient?.Close();
         }
 

--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using OSDP.Net.Connections;
+using OSDP.Net.Messages;
+using OSDP.Net.Messages.ACU;
+using OSDP.Net.Messages.PD;
+using OSDP.Net.Messages.SecureChannel;
+using OSDP.Net.Model.CommandData;
+using OSDP.Net.Model.ReplyData;
+
+
+namespace OSDP.Net;
+
+public class Device : IDisposable
+{
+    private readonly ILogger _logger;
+    private CancellationTokenSource _cancellationTokenSource;
+    private Task _listenerTask = Task.CompletedTask;
+    private ConcurrentQueue<ReplyData> _pendingPollReplies = new ();
+
+
+    public Device(ILogger<DeviceProxy> logger = null)
+    {
+        _logger = logger;
+    }
+
+    /// <inheritdoc/>
+    public void Dispose() => Dispose(true);
+
+    public bool IsConnected { get; private set; } = false;
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _cancellationTokenSource?.Dispose();
+        }
+    }
+
+    public async void StartListening(IOsdpConnection connection)
+    {
+        var cancellationTokenSource = _cancellationTokenSource;
+        if (cancellationTokenSource != null) return;
+        _cancellationTokenSource = cancellationTokenSource = new CancellationTokenSource();
+
+        _listenerTask = await Task.Factory.StartNew(async () =>
+        {
+            try
+            {
+                connection.Open();
+                
+                var channel = new PdMessageSecureChannel(connection);
+
+                while (!_cancellationTokenSource.IsCancellationRequested)
+                {
+                    var command = await channel.ReadNextCommand(_cancellationTokenSource.Token);
+                    if (command != null)
+                    {
+                        var reply = HandleCommand(command);
+                        channel.SendReply(reply);
+                    }
+                }
+
+                IsConnected = false;
+            }
+            catch (Exception exception)
+            {
+                _logger?.LogError(exception, $"Unexpected exception in polling loop");
+            }
+        }, TaskCreationOptions.LongRunning);
+    }
+
+    public async void StopListening()
+    {
+        var cancellationTokenSource = _cancellationTokenSource;
+        if (cancellationTokenSource != null)
+        {
+            cancellationTokenSource.Cancel();
+
+            // TODO: why not block indefinitely?
+            //_shutdownComplete.WaitOne(TimeSpan.FromSeconds(1));
+            await _listenerTask;
+            _cancellationTokenSource = null;
+        }
+    }
+
+    public void EnqueuePollReply(ReplyData reply) => _pendingPollReplies.Enqueue(reply);
+
+    protected virtual Messages.PD.Reply HandleCommand(IncomingMessage command) => 
+        new(command, (CommandType)command.Type switch
+        {
+            CommandType.Poll => HandlePoll(),
+            CommandType.IdReport => HandleIdReport(),
+            CommandType.TextOutput => HandleTextOutput(command),
+            CommandType.BuzzerControl => HandleBuzzerControl(command),
+            CommandType.OutputControl => HandleOutputControl(command),
+            CommandType.DeviceCapabilities => HandleDeviceCap(command),
+            CommandType.PivData => HandlePivData(command),
+            CommandType.ManufacturerSpecific => HandleManufacturerCommand(command),
+            _ => HandleUnknownCommand(command),
+        });
+
+    protected virtual ReplyData HandlePoll()
+    {
+        if (_pendingPollReplies.TryDequeue(out var reply)) return reply;
+        return new Ack();
+    }
+
+    protected virtual ReplyData HandleIdReport()
+    {
+        return new DeviceIdentification([ 0x01, 0x02, 0x03 ], 0x04, 0x05, 0x06070809, 0x0a, 0x0b, 0x0c);
+    }
+
+    protected virtual ReplyData HandleTextOutput(IncomingMessage command)
+    {
+        return new Ack();
+    }
+
+    protected virtual ReplyData HandleBuzzerControl(IncomingMessage command)
+    {
+        return new Ack();
+    }
+
+    protected virtual ReplyData HandleOutputControl(IncomingMessage command)
+    {
+        return new Ack();
+    }
+
+    protected virtual ReplyData HandleDeviceCap(IncomingMessage command)
+    {
+        return new Ack();
+    }
+
+    protected virtual ReplyData HandlePivData(IncomingMessage command)
+    {
+        var payload = GetPIVData.ParseData(command.Payload);
+
+        // TODO: This is where we would trigger async gathering of PIV data which
+        // will be returned through a reply to a future poll command
+
+        return new Ack();
+    }
+    protected virtual ReplyData HandleManufacturerCommand(IncomingMessage command)
+    {
+        var payload = Model.CommandData.ManufacturerSpecific.ParseData(command.Payload);
+
+        // TODO: This is where we would trigger async manufacturer-specific command
+        // reply to which would be returned as a reply to a future poll command
+
+        return new Ack();
+    }
+
+    protected virtual ReplyData HandleUnknownCommand(IncomingMessage command)
+    {
+        byte[] rawMessage = command.OriginalMessageData.ToArray();
+
+        _logger.LogInformation($"Unexpected Command: {{cmd_bytes}}!!{Environment.NewLine}" +
+            $"    Cmd: {{cmd_code}}({{cmd_name}}){Environment.NewLine}" +
+            $"    Payload: {{payload}}",
+            string.Join("-", rawMessage.Select(x => x.ToString("X2"))),
+            command.Type, Enum.GetName(typeof(CommandType), command.Type),
+            string.Join("-", command.Payload.Select(x => x.ToString("X2"))));
+
+        return new Nak(ErrorCode.UnknownCommandCode);
+    }
+}

--- a/src/OSDP.Net/DeviceProxy.cs
+++ b/src/OSDP.Net/DeviceProxy.cs
@@ -20,7 +20,7 @@ namespace OSDP.Net;
 /// <summary>
 /// 
 /// </summary>
-public class DeviceProxy : IComparable<DeviceProxy>, IDisposable
+public class DeviceProxy : IComparable<DeviceProxy>,IDisposable
 {
     private const int RetryAmount = 2;
 
@@ -29,11 +29,9 @@ public class DeviceProxy : IComparable<DeviceProxy>, IDisposable
     private readonly SecureChannel _secureChannel = new();
     private readonly bool _useSecureChannel;
     private readonly ILogger<DeviceProxy> _logger;
-    private readonly AutoResetEvent _shutdownComplete = new (false);
-    
+
     private int _counter = RetryAmount;
     private DateTime _lastValidReply = DateTime.MinValue;
-    private CancellationTokenSource _cancellationTokenSource;
 
     private Command _retryCommand;
 
@@ -90,121 +88,14 @@ public class DeviceProxy : IComparable<DeviceProxy>, IDisposable
     /// </summary>
     internal bool HasQueuedCommand => _commands.Any();
 
+    public void Dispose() {}
+
     /// <inheritdoc />
     public int CompareTo(DeviceProxy other)
     {
         if (ReferenceEquals(this, other)) return 0;
         if (ReferenceEquals(null, other)) return 1;
         return Address.CompareTo(other.Address);
-    }
-
-    /// <summary>
-    /// Starts listening for incoming commands from the specified IOsdpConnection.
-    /// </summary>
-    /// <param name="connection">The IOsdpConnection to listen for commands.</param>
-    /// <param name="commandProcessing">The ICommandProcessing instance to handle the incoming commands.</param>
-    public void StartListening(IOsdpConnection connection, ICommandProcessing commandProcessing)
-    {
-        var cancellationTokenSource = _cancellationTokenSource;
-        if (cancellationTokenSource != null) return;
-        _cancellationTokenSource = cancellationTokenSource = new CancellationTokenSource();
-        
-        Task.Factory.StartNew(async () =>
-        {
-            var secureChannel = new PdMessageSecureChannel();
-
-            try
-            {
-                connection.Open();
-                while (!_cancellationTokenSource.IsCancellationRequested)
-                {
-                    var commandBuffer = await GetCommand(connection);
-                    
-                    if (commandBuffer.Length == 0) continue;
-
-                    var incomingMessage = new IncomingMessage(commandBuffer, secureChannel);
-
-                    HandleResponse(connection, secureChannel, incomingMessage, commandProcessing);
-
-                    if (incomingMessage.Sequence > 0) _lastValidReply = DateTime.UtcNow;
-                }
-            }
-            catch(Exception exception)
-            {
-                _logger?.LogError(exception, $"Unexpected exception in polling loop");
-            }
-        }, TaskCreationOptions.LongRunning);
-
-        _shutdownComplete.Set();
-    }
-
-    private void HandleResponse(IOsdpConnection connection, PdMessageSecureChannel secureChannel, IncomingMessage incomingMessage, ICommandProcessing commandProcessing)
-    {
-        PayloadData replyData;
-
-        switch ((CommandType)incomingMessage.Type)
-        {
-            case CommandType.Poll:
-                replyData = commandProcessing.Poll();
-                break;
-            case CommandType.IdReport:
-                replyData = commandProcessing.IdReport();
-                break;
-            default:
-                replyData = new Nak(ErrorCode.UnknownCommandCode);
-                break;
-        }
-
-        var reply = new OutgoingMessage(replyData);
-        var data = reply.BuildMessage(incomingMessage.ControlBlock, secureChannel);
-        var buffer = new byte[data.Length + 1];
-
-        // Section 5.7 states that transmitting device shall guarantee an idle time between packets. This is
-        // accomplished by sending a character with all bits set to 1. The driver byte is required by
-        // converters and multiplexers to sense when line is idle.
-        buffer[0] = Bus.DriverByte;
-        Buffer.BlockCopy(data, 0, buffer, 1, data.Length);
-            
-        Debug.WriteLine("Outgoing: " + BitConverter.ToString(data));
-        
-        connection.WriteAsync(buffer);
-    }
-
-    private async Task<byte[]> GetCommand(IOsdpConnection connection)
-    {
-        var commandBuffer = new Collection<byte>();
-
-        if (!await Bus.WaitForStartOfMessage(connection, commandBuffer, true, _cancellationTokenSource.Token)
-                .ConfigureAwait(false))
-        {
-            return Array.Empty<byte>();
-        }
-
-        if (!await Bus.WaitForMessageLength(connection, commandBuffer, _cancellationTokenSource.Token).ConfigureAwait(false))
-        {
-            throw new TimeoutException("Timeout waiting for command message length");
-        }
-
-        if (!await Bus.WaitForRestOfMessage(connection, commandBuffer, Bus.ExtractMessageLength(commandBuffer),
-                _cancellationTokenSource.Token).ConfigureAwait(false))
-        {
-            throw new TimeoutException("Timeout waiting for command of reply message");
-        }
-        
-        Debug.WriteLine("Incoming: " + BitConverter.ToString(commandBuffer.ToArray()));
-        
-        return commandBuffer.ToArray();
-    }
-
-    public void StopListening()
-    {
-        var cancellationTokenSource = _cancellationTokenSource;
-        if (cancellationTokenSource != null)
-        {
-            cancellationTokenSource.Cancel();
-            _shutdownComplete.WaitOne(TimeSpan.FromSeconds(1));
-            _cancellationTokenSource = null;
-        }
     }
 
     /// <summary>
@@ -321,18 +212,4 @@ public class DeviceProxy : IComparable<DeviceProxy>, IDisposable
     {
         _secureChannel.CreateNewRandomNumber();
     }
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        _shutdownComplete?.Dispose();
-        _cancellationTokenSource?.Dispose();
-    }
-}
-
-public interface ICommandProcessing
-{
-    PayloadData Poll();
-
-    PayloadData IdReport();
 }

--- a/src/OSDP.Net/Messages/ACU/Control.cs
+++ b/src/OSDP.Net/Messages/ACU/Control.cs
@@ -1,6 +1,6 @@
 namespace OSDP.Net.Messages.ACU
 {
-    internal class Control
+    public class Control
     {
         private readonly bool _hasSecurityControlBlock;
 

--- a/src/OSDP.Net/Messages/IncomingMessage.cs
+++ b/src/OSDP.Net/Messages/IncomingMessage.cs
@@ -11,7 +11,7 @@ namespace OSDP.Net.Messages
     /// class with extra properties/methods that specifically indicate the parsing and
     /// validation of incoming raw bytes.
     /// </summary>
-    internal class IncomingMessage : Message
+    public class IncomingMessage : Message
     {
         private const ushort MessageHeaderSize = 6;
         private readonly byte[] _originalMessage;

--- a/src/OSDP.Net/Messages/SecureChannel/MessageSecureChannel.cs
+++ b/src/OSDP.Net/Messages/SecureChannel/MessageSecureChannel.cs
@@ -16,13 +16,8 @@ namespace OSDP.Net.Messages.SecureChannel;
 /// this new class hierarchy depends on IMessageChannel interface to interact with the secure
 /// channel context and this class is the base implementation for that
 /// </summary>
-internal abstract class MessageSecureChannel : IMessageSecureChannel
+public abstract class MessageSecureChannel : IMessageSecureChannel
 {
-    /// <summary>
-    /// Optional logger instance
-    /// </summary>
-    protected readonly ILogger Logger;
-
     /// <summary>
     /// Initializes a new instance of SecurityChannel2 class
     /// </summary>
@@ -38,6 +33,11 @@ internal abstract class MessageSecureChannel : IMessageSecureChannel
         Context = context ?? new();
         Logger = loggerFactory?.CreateLogger(GetType());
     }
+
+    /// <summary>
+    /// Optional logger instance
+    /// </summary>
+    protected ILogger Logger { get; }
 
     /// <summary>
     /// Security state used by the channel

--- a/src/OSDP.Net/Messages/SecureChannel/PdMessageSecureChannel.cs
+++ b/src/OSDP.Net/Messages/SecureChannel/PdMessageSecureChannel.cs
@@ -1,6 +1,15 @@
 ﻿using System;
+using System.Buffers.Binary;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using OSDP.Net.Connections;
+using OSDP.Net.Messages.SecureChannel;
 using OSDP.Net.Model.ReplyData;
 
 namespace OSDP.Net.Messages.SecureChannel
@@ -9,10 +18,8 @@ namespace OSDP.Net.Messages.SecureChannel
     /// Message channel which represents the Periphery Device (PD) side of the OSDP 
     /// communications (i.e. OSDP commands are received and replies are sent out)
     /// </summary>
-    internal class PdMessageSecureChannel : MessageSecureChannel
+    public class PdMessageSecureChannelBase : MessageSecureChannel
     {
-        private byte[] _expectedServerCryptogram;
-
         /// <summary>
         /// Initializes a new instance of the PDMessageChannel
         /// </summary>
@@ -23,8 +30,8 @@ namespace OSDP.Net.Messages.SecureChannel
         /// channels</param>
         /// <param name="loggerFactory">Optional logger factory from which a logger object for the
         /// message channel will be acquired</param>
-        public PdMessageSecureChannel(SecurityContext context = null, ILoggerFactory loggerFactory = null) 
-            : base(context, loggerFactory) {}
+        public PdMessageSecureChannelBase(SecurityContext context = null, ILoggerFactory loggerFactory = null)
+            : base(context, loggerFactory) { }
 
         /// <inheritdoc />
         public override void EncodePayload(byte[] payload, Span<byte> destination) =>
@@ -36,7 +43,102 @@ namespace OSDP.Net.Messages.SecureChannel
         /// <inheritdoc />
         public override ReadOnlySpan<byte> GenerateMac(ReadOnlySpan<byte> message, bool isIncoming) =>
             isIncoming ? GenerateCommandMac(message) : GenerateReplyMac(message);
-        
+    }
+
+    public class PdMessageSecureChannel : PdMessageSecureChannelBase
+    {
+        private readonly IOsdpConnection _connection;
+        private readonly Guid _connectionId = Guid.NewGuid();
+        private byte[] _expectedServerCryptogram;
+
+        public PdMessageSecureChannel(IOsdpConnection connection, SecurityContext context = null, ILoggerFactory loggerFactory = null)
+            : base(context, loggerFactory) 
+        {
+            _connection = connection;
+        }
+
+        public async Task<IncomingMessage> ReadNextCommand(CancellationToken cancellationToken = default)
+        {
+            var commandBuffer = new Collection<byte>();
+
+            if (!await Bus.WaitForStartOfMessage(_connection, commandBuffer, true, cancellationToken)
+                    .ConfigureAwait(false))
+            {
+                return null;
+            }
+
+            if (!await Bus.WaitForMessageLength(_connection, commandBuffer, cancellationToken).ConfigureAwait(false))
+            {
+                throw new TimeoutException("Timeout waiting for command message length");
+            }
+
+            if (!await Bus.WaitForRestOfMessage(_connection, commandBuffer, Bus.ExtractMessageLength(commandBuffer),
+                    cancellationToken).ConfigureAwait(false))
+            {
+                throw new TimeoutException("Timeout waiting for command of reply message");
+            }
+
+            // TODO: best way to log?
+            Debug.WriteLine("Incoming: " + BitConverter.ToString(commandBuffer.ToArray()));
+
+            var command = new IncomingMessage(commandBuffer.ToArray().AsSpan(), this, _connectionId);
+
+            if (command.Type != (byte)CommandType.Poll)
+            {
+                Logger.LogInformation("Received Command: {cmd}", Enum.GetName(typeof(CommandType), command.Type));
+            }
+
+            var commandHandled = await HandleCommand(command);
+            return commandHandled ? await ReadNextCommand() : command;
+        }
+
+        public async Task SendReply(Reply reply)
+        {
+            if (reply.IssuingCommand.Type != (byte)CommandType.Poll)
+            {
+                Logger.LogInformation("Sending Back Reply: {reply}", Enum.GetName(typeof(ReplyType), reply.Type));
+            }
+
+            // Section 5.7 states that transmitting device shall guarantee an idle time between packets. This is
+            // accomplished by sending a character with all bits set to 1. The driver byte is required by
+            // converters and multiplexers to sense when line is idle.
+            var driverBytePrefix = new byte[] { Bus.DriverByte };
+            await _connection.WriteAsync(reply.BuildReply(this, driverBytePrefix));
+        }
+
+        private async Task<bool> HandleCommand(IncomingMessage command)
+        {
+            Reply reply;
+
+            switch (command.IsValidMac, (CommandType)command.Type)
+            {
+                case (false, _):
+                    reply = HandleInvalidMac(command);
+                    break;
+                case (true, CommandType.SessionChallenge):
+                    reply = HandleSessionChallenge(command);
+                    break;
+                case (true, CommandType.ServerCryptogram):
+                    reply = HandleSCrypt(command);
+                    break;
+                default:
+                    return false;
+            }
+
+            await SendReply(reply);
+
+            if (command.Type == (byte)CommandType.ServerCryptogram)
+            {
+                Context.IsSecurityEstablished = true;
+            }
+
+            return true;
+        }
+        private Reply HandleInvalidMac(IncomingMessage command)
+        {
+            return new Reply(command, new Nak(ErrorCode.CommunicationSecurityNotMet));
+        }
+
         /// <summary>
         /// Default handler for the SessionChallenge message received on the channel
         /// </summary>
@@ -44,31 +146,27 @@ namespace OSDP.Net.Messages.SecureChannel
         /// <returns>A message representing a reply to the SessionChallenge</returns>
         protected OutgoingMessage HandleSessionChallenge(IncomingMessage command)
         {
-            // TODO: this should be some kind of unique identifier, but a) not sure how to generate it and b) seems
-            // the other side presently simply ignores these bytes. So for time being simply leaving this uninitialized
-            byte[] cUID = new byte[8];
-
-            byte[] rndA = command.Payload;
-            byte[] rndB = new byte[8];
-
-            // TODO: we should validate payload and SCB type
-
             // It is possible that ACU may decide to re-challenge us after a channel was already set up.
             // In that case, let's make sure we clear this flag to indicate that we do NOT in fact have security
             // established
             Context.IsSecurityEstablished = false;
 
-            // generate RND.B
-            new Random().NextBytes(rndB);
-
             // generate a set of session keys: S-ENC, S-MAC1, S-MAC2 using command.Payload (which is RND.A)
             var crypto = SecurityContext.CreateCypher(SecurityContext.DefaultKey, true);
+            byte[] rndA = command.Payload;
+
+            // TODO: we should validate payload and SCB type
 
             Context.Enc = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x82, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
             Context.SMac1 = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x01, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
             Context.SMac2 = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x02, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
 
-            // generate client cryptogram
+            // TODO: this should be some kind of unique identifier, but a) not sure how to generate it and b) seems
+            // the other side presently simply ignores these bytes. So for time being simply leaving this uninitialized
+            byte[] cUID = new byte[8];
+            byte[] rndB = new byte[8];
+
+            new Random().NextBytes(rndB);
             crypto.Key = Context.Enc;
             var clientCryptogram = SecurityContext.GenerateKey(crypto, rndA, rndB);
             _expectedServerCryptogram = SecurityContext.GenerateKey(crypto, rndB, rndA);

--- a/src/OSDP.Net/Messages/SecureChannel/SecurityContext.cs
+++ b/src/OSDP.Net/Messages/SecureChannel/SecurityContext.cs
@@ -9,7 +9,7 @@ namespace OSDP.Net.Messages.SecureChannel;
 /// This state data is placed into its own class to facilitate use cases where multiple channels
 /// (i.e. one for incoming packets; one for outgoing) have to share the same security state.
 /// </summary>
-internal class SecurityContext
+public class SecurityContext
 {
     public static readonly byte[] DefaultKey = "0123456789:;<=>?"u8.ToArray();
     

--- a/src/OSDP.Net/Model/ReplyData/DeviceIdentification.cs
+++ b/src/OSDP.Net/Model/ReplyData/DeviceIdentification.cs
@@ -93,7 +93,7 @@ namespace OSDP.Net.Model.ReplyData
         /// <inheritdoc/>
         public override string ToString(int indent)
         {
-            string padding = new string(' ', indent);
+            string padding = new (' ', indent);
 
             var build = new StringBuilder();
             build.AppendLine($"{padding}     Vendor Code: {BitConverter.ToString(VendorCode.ToArray())}");

--- a/src/OSDP.Net/Tracing/MessageSpy.cs
+++ b/src/OSDP.Net/Tracing/MessageSpy.cs
@@ -1,75 +1,77 @@
 ﻿using System;
 using OSDP.Net.Messages;
+using OSDP.Net.Messages.ACU;
+using OSDP.Net.Messages.PD;
 using OSDP.Net.Messages.SecureChannel;
 
 namespace OSDP.Net.Tracing;
 
 internal class MessageSpy
 {
-        private readonly SecurityContext _context;
-        private readonly MessageSecureChannel _commandSpyChannel;
-        private readonly MessageSecureChannel _replySpyChannel;
-        private readonly byte[] _securityKey;
+    private readonly SecurityContext _context;
+    private readonly MessageSecureChannel _commandSpyChannel;
+    private readonly MessageSecureChannel _replySpyChannel;
+    private readonly byte[] _securityKey;
 
-        public MessageSpy(byte[] securityKey = null)
+    public MessageSpy(byte[] securityKey = null)
+    {
+        _context = new SecurityContext();
+        _commandSpyChannel = new PdMessageSecureChannelBase(_context);
+        _replySpyChannel = new ACUMessageSecureChannel(_context);
+        _securityKey = securityKey ?? SecurityContext.DefaultKey;
+    }
+
+    public byte PeekAddressByte(ReadOnlySpan<byte> data)
+    {
+        return data[1];
+    }
+
+    public IncomingMessage ParseCommand(byte[] data)
+    {
+        var command = new IncomingMessage(data, _commandSpyChannel, Guid.Empty);
+
+        return (CommandType)command.Type switch
         {
-            _context = new SecurityContext();
-            _commandSpyChannel = new PdMessageSecureChannel(_context);
-            _replySpyChannel = new ACUMessageSecureChannel(_context);
-            _securityKey = securityKey ?? SecurityContext.DefaultKey;
-        }
+            CommandType.SessionChallenge => HandleSessionChallenge(command),
+            CommandType.ServerCryptogram => HandleSCrypt(command),
+            _ => command
+        };
+    }
 
-        public byte PeekAddressByte(ReadOnlySpan<byte> data)
+    public IncomingMessage ParseReply(byte[] data)
+    {
+        var reply = new IncomingMessage(data, _replySpyChannel, Guid.Empty);
+
+        return (ReplyType)reply.Type switch
         {
-            return data[1];
-        }
+            ReplyType.InitialRMac => HandleInitialRMac(reply),
+            _ => reply
+        };
+    }
 
-        public IncomingMessage ParseCommand(byte[] data)
-        {
-            var command = new IncomingMessage(data, _commandSpyChannel);
+    private IncomingMessage HandleSessionChallenge(IncomingMessage command)
+    {
+        byte[] rndA = command.Payload;
+        var crypto = SecurityContext.CreateCypher(_securityKey, true);
+        _context.Enc = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x82, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
+        _context.SMac1 = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x01, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
+        _context.SMac2 = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x02, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
+        return command;
+    }
 
-            return (CommandType)command.Type switch
-            {
-                CommandType.SessionChallenge => HandleSessionChallenge(command),
-                CommandType.ServerCryptogram => HandleSCrypt(command),
-                _ => command
-            };
-        }
+    private IncomingMessage HandleSCrypt(IncomingMessage command)
+    {
+        var serverCryptogram = command.Payload;
+        using var crypto = SecurityContext.CreateCypher(_context.SMac1, true);
+        var intermediate = SecurityContext.GenerateKey(crypto, serverCryptogram);
+        crypto.Key = _context.SMac2;
+        _context.RMac = SecurityContext.GenerateKey(crypto, intermediate);
+        return command;
+    }
 
-        public IncomingMessage ParseReply(byte[] data)
-        {
-            var reply = new IncomingMessage(data, _replySpyChannel);
-
-            return (ReplyType)reply.Type switch
-            {
-                ReplyType.InitialRMac => HandleInitialRMac(reply),
-                _ => reply
-            };
-        }
-
-        private IncomingMessage HandleSessionChallenge(IncomingMessage command)
-        {
-            byte[] rndA = command.Payload;
-            var crypto = SecurityContext.CreateCypher(_securityKey, true);
-            _context.Enc = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x82, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
-            _context.SMac1 = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x01, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
-            _context.SMac2 = SecurityContext.GenerateKey(crypto, new byte[] { 0x01, 0x02, rndA[0], rndA[1], rndA[2], rndA[3], rndA[4], rndA[5] });
-            return command;
-        }
-
-        private IncomingMessage HandleSCrypt(IncomingMessage command)
-        {
-            var serverCryptogram = command.Payload;
-            using var crypto = SecurityContext.CreateCypher(_context.SMac1, true);
-            var intermediate = SecurityContext.GenerateKey(crypto, serverCryptogram);
-            crypto.Key = _context.SMac2;
-            _context.RMac = SecurityContext.GenerateKey(crypto, intermediate);
-            return command;
-        }
-
-        private IncomingMessage HandleInitialRMac(IncomingMessage reply)
-        {
-            _context.IsSecurityEstablished = true;
-            return reply;
-        }
+    private IncomingMessage HandleInitialRMac(IncomingMessage reply)
+    {
+        _context.IsSecurityEstablished = true;
+        return reply;
+    }
 }

--- a/src/OSDP.Net/Tracing/MessageSpy.cs
+++ b/src/OSDP.Net/Tracing/MessageSpy.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using OSDP.Net.Messages;
-using OSDP.Net.Messages.ACU;
-using OSDP.Net.Messages.PD;
 using OSDP.Net.Messages.SecureChannel;
 
 namespace OSDP.Net.Tracing;
@@ -28,7 +26,7 @@ internal class MessageSpy
 
     public IncomingMessage ParseCommand(byte[] data)
     {
-        var command = new IncomingMessage(data, _commandSpyChannel, Guid.Empty);
+        var command = new IncomingMessage(data, _commandSpyChannel);
 
         return (CommandType)command.Type switch
         {
@@ -40,7 +38,7 @@ internal class MessageSpy
 
     public IncomingMessage ParseReply(byte[] data)
     {
-        var reply = new IncomingMessage(data, _replySpyChannel, Guid.Empty);
+        var reply = new IncomingMessage(data, _replySpyChannel);
 
         return (ReplyType)reply.Type switch
         {

--- a/src/samples/CardReader/Program.cs
+++ b/src/samples/CardReader/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections;
 using OSDP.Net;
 using OSDP.Net.Connections;
+using OSDP.Net.Model;
 using OSDP.Net.Model.ReplyData;
 
 
@@ -31,7 +32,7 @@ device.StopListening();
 
 class MySampleDevice : Device
 {
-    protected override ReplyData HandleIdReport()
+    protected override PayloadData HandleIdReport()
     {
         return new DeviceIdentification(new byte[] { 0x00, 0x00, 0x00 }, 0, 1, 0, 0, 0, 0);
     }


### PR DESCRIPTION
This PR puts the broad brushstrokes in place as far as...

1. Separation of Device (PD side) and DeviceProxy (ACU side) classes and their responsibilities
2. Introduces the use of `PdMessageSecureChannel` channel as the an actual channel class (i.e. ALL commands are received from this class and all replies are sent to this class, while underlying IOsdpConnection is maintained internally to the channel)
3. Introduces SecureChannel negotiation

HEADS UP: THESE CHANGES ARE UNTESTED. 

My next step with these changes would be to spin up the sample card reader with IOsdpTcpServerConnection, point the Console at it and get the two sides of OSDP protocol to talk to each other. Haven't gotten there.