### PR TITLE
Make PD and ACU talk to each other (secure and via both TCP and Serial)

### DIFF
--- a/src/OSDP.Net.Tests/ControlPanelTest.cs
+++ b/src/OSDP.Net.Tests/ControlPanelTest.cs
@@ -39,7 +39,6 @@ namespace OSDP.Net.Tests
         {
             // Arrange
             var mockConnection = new MockConnection();
-            await mockConnection.Object.Open();
             
             var panel = new ControlPanel();
             Guid id = panel.StartConnection(mockConnection.Object);

--- a/src/OSDP.Net.Tests/ControlPanelTest.cs
+++ b/src/OSDP.Net.Tests/ControlPanelTest.cs
@@ -39,7 +39,7 @@ namespace OSDP.Net.Tests
         {
             // Arrange
             var mockConnection = new MockConnection();
-            mockConnection.Object.Open();
+            await mockConnection.Object.Open();
             
             var panel = new ControlPanel();
             Guid id = panel.StartConnection(mockConnection.Object);

--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -203,7 +203,7 @@ namespace OSDP.Net
                 {
                     try
                     {
-                        Connection.Open();
+                        await Connection.Open();
                     }
                     catch (Exception exception)
                     {
@@ -343,7 +343,7 @@ namespace OSDP.Net
             // Polling task is complete. Time to close the connection.
             try
             { 
-                Connection.Close();
+                await Connection.Close();
             }
             catch(Exception exception)
             {

--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OSDP.Net/Connections/IOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/IOsdpConnection.cs
@@ -23,6 +23,16 @@ namespace OSDP.Net.Connections
         TimeSpan ReplyTimeout { get; set; }
 
         /// <summary>
+        /// Open the connection for communications
+        /// </summary>
+        Task Open();
+
+        /// <summary>
+        /// Close the connection for communications
+        /// </summary>
+        Task Close();
+
+        /// <summary>
         /// Write to connection
         /// </summary>
         /// <param name="buffer">Array of bytes to write</param>
@@ -35,24 +45,16 @@ namespace OSDP.Net.Connections
         /// <param name="token">Cancellation token to end reading of bytes</param>
         /// <returns>Number of actual bytes read</returns>
         Task<int> ReadAsync(byte[] buffer, CancellationToken token);
-
-        /// <summary>
-        /// Close the connection for communications
-        /// </summary>
-        void Close();
-
-        /// <summary>
-        /// Open the connection for communications
-        /// </summary>
-        void Open();
     }
 
     public interface IOsdpServer : IDisposable
     {
-        void Start(Func<IOsdpConnection, Task> newConnectionHandler);
+        Task Start(Func<IOsdpConnection, Task> newConnectionHandler);
 
-        void Stop();
+        Task Stop();
 
         bool IsRunning { get; }
+
+        int ConnectionCount { get; }
     }
 }

--- a/src/OSDP.Net/Connections/IOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/IOsdpConnection.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 namespace OSDP.Net.Connections
 {
     /// <summary>
-    /// Defines a connection for communicating with PDs
+    /// Defines a connection for communicating via OSDP protocol
     /// </summary>
     public interface IOsdpConnection : IDisposable
     {
@@ -47,14 +47,34 @@ namespace OSDP.Net.Connections
         Task<int> ReadAsync(byte[] buffer, CancellationToken token);
     }
 
+    /// <summary>
+    /// Defines a server side of OSDP connection which is intended to listen for
+    /// incoming connections as they are established
+    /// </summary>
+
     public interface IOsdpServer : IDisposable
     {
+        /// <summary>
+        /// Starts listening for incoming connections
+        /// </summary>
+        /// <param name="newConnectionHandler">Callback to be invoked whenever a new connection is accepted</param>
         Task Start(Func<IOsdpConnection, Task> newConnectionHandler);
 
+        /// <summary>
+        /// Stops the server, which stops the listener and terminates
+        /// any presently open connections to the server
+        /// </summary>
+        /// <returns></returns>
         Task Stop();
 
+        /// <summary>
+        /// Indicates whether or not the server is running
+        /// </summary>
         bool IsRunning { get; }
 
+        /// <summary>
+        /// The number of active connections being tracked by the server
+        /// </summary>
         int ConnectionCount { get; }
     }
 }

--- a/src/OSDP.Net/Connections/IOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/IOsdpConnection.cs
@@ -7,7 +7,7 @@ namespace OSDP.Net.Connections
     /// <summary>
     /// Defines a connection for communicating with PDs
     /// </summary>
-    public interface IOsdpConnection
+    public interface IOsdpConnection : IDisposable
     {
         /// <summary>Speed of the connection</summary>
         int BaudRate { get; }
@@ -23,16 +23,6 @@ namespace OSDP.Net.Connections
         TimeSpan ReplyTimeout { get; set; }
 
         /// <summary>
-        /// Open the connection for communications
-        /// </summary>
-        void Open();
-
-        /// <summary>
-        /// Close the connection for communications
-        /// </summary>
-        void Close();
-
-        /// <summary>
         /// Write to connection
         /// </summary>
         /// <param name="buffer">Array of bytes to write</param>
@@ -45,5 +35,24 @@ namespace OSDP.Net.Connections
         /// <param name="token">Cancellation token to end reading of bytes</param>
         /// <returns>Number of actual bytes read</returns>
         Task<int> ReadAsync(byte[] buffer, CancellationToken token);
+
+        /// <summary>
+        /// Close the connection for communications
+        /// </summary>
+        void Close();
+
+        /// <summary>
+        /// Open the connection for communications
+        /// </summary>
+        void Open();
+    }
+
+    public interface IOsdpServer : IDisposable
+    {
+        void Start(Func<IOsdpConnection, Task> newConnectionHandler);
+
+        void Stop();
+
+        bool IsRunning { get; }
     }
 }

--- a/src/OSDP.Net/Connections/OsdpConnection.cs
+++ b/src/OSDP.Net/Connections/OsdpConnection.cs
@@ -10,35 +10,51 @@ using System.Threading.Tasks;
 
 namespace OSDP.Net.Connections
 {
+    /// <summary>
+    /// Base OSDP connection class
+    /// </summary>
     public abstract class OsdpConnection : IOsdpConnection
     {
         private bool _disposedValue;
 
+        /// <summary>
+        /// Creates an instance of OsdpConnection
+        /// </summary>
+        /// <param name="baudRate">Baud rate for OSDP comms</param>
         protected OsdpConnection(int baudRate)
         {
             BaudRate = baudRate;
         }   
 
+        /// <inheritdoc/>
         public int BaudRate { get; }
 
+        /// <inheritdoc/>
         public virtual bool IsOpen { get; protected set; }
 
+        /// <inheritdoc/>
         public TimeSpan ReplyTimeout { get; set; } = TimeSpan.FromMilliseconds(200);
 
+        /// <inheritdoc/>
         public abstract Task Close();
-        
+
+        /// <inheritdoc/>
         public abstract Task Open();
-        
+
+        /// <inheritdoc/>
         public abstract Task<int> ReadAsync(byte[] buffer, CancellationToken token);
-        
+
+        /// <inheritdoc/>
         public abstract Task WriteAsync(byte[] buffer);
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             Dispose(disposing: true);
             GC.SuppressFinalize(this);
         }
 
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -54,65 +70,89 @@ namespace OSDP.Net.Connections
     }
 
 
+    /// <summary>
+    /// Base class for an OSDP server that listens for incoming connections
+    /// </summary>
     public abstract class OsdpServer : IOsdpServer
     {
         private bool _disposedValue;
         private readonly ConcurrentDictionary<Task, OsdpConnection> _connections = new();
-        private readonly ILogger _logger;
 
+        /// <summary>
+        /// Creates a new instance of OsdpServer
+        /// </summary>
+        /// <param name="loggerFactory">Optional logger factory</param>
         public OsdpServer(ILoggerFactory loggerFactory = null)
         {
-            _logger = loggerFactory?.CreateLogger<OsdpServer>();
+            LoggerFactory = loggerFactory;
+            Logger = loggerFactory?.CreateLogger<OsdpServer>();
         }
 
+        /// <inheritdoc/>
         public bool IsRunning { get; protected set; }
 
+        /// <inheritdoc/>
         public int ConnectionCount { get => _connections.Count; }
 
+        /// <summary>
+        /// Logger factory if one was specified at instantitation
+        /// </summary>
+        protected ILoggerFactory LoggerFactory { get; }
+
+        /// <summary>
+        /// Logger instance used by the server if a factory was specified at instantiation
+        /// </summary>
+        protected ILogger Logger { get; }
+
+        /// <inheritdoc/>
         public abstract Task Start(Func<IOsdpConnection, Task> newConnectionHandler);
 
+        /// <inheritdoc/>
         public virtual async Task Stop()
         {
             IsRunning = false;
 
-            _logger.LogDebug("Stopping OSDP Server connections...");
+            Logger.LogDebug("Stopping OSDP Server connections...");
 
             while (true)
             {
                 var entries = _connections.ToArray();
                 if (entries.Length == 0) break;
 
-                foreach (var item in entries)
-                {
-                    item.Value.Close();
-                }
-
+                await Task.WhenAll(entries.Select(item => item.Value.Close()));
                 await Task.WhenAll(entries.Select(x => x.Key));
             }
 
-            _logger.LogDebug("OSDP Server STOPPED");
+            Logger.LogDebug("OSDP Server STOPPED");
         }
 
+        /// <inheritdoc/>
         public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);
         }
 
+        /// <summary>
+        /// Intended to be called by a deriving class whenever it spins off a dedicated
+        /// listening loop task for a newly created OsdpConnection
+        /// </summary>
+        /// <param name="connection"></param>
+        /// <param name="task"></param>
         protected void RegisterConnection(OsdpConnection connection, Task task)
         {
             Task.Run(async () =>
             {
-                _logger?.LogDebug("New OSDP connection opened - {}", _connections.Count + 1);
-
                 _connections.TryAdd(task, connection);
-                if (!IsRunning) connection.Close();
+                if (!IsRunning) await connection.Close();
+                Logger?.LogDebug("New OSDP connection opened - {}", _connections.Count);
                 await task;
-                _logger?.LogDebug("OSDP connection terminated - {}", _connections.Count - 1);
                 _connections.TryRemove(task, out _);
+                Logger?.LogDebug("OSDP connection terminated - {}", _connections.Count);
             });
         }
 
+        /// <inheritdoc/>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)

--- a/src/OSDP.Net/Connections/OsdpConnection.cs
+++ b/src/OSDP.Net/Connections/OsdpConnection.cs
@@ -1,10 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Text;
+﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -54,7 +48,13 @@ namespace OSDP.Net.Connections
             GC.SuppressFinalize(this);
         }
 
-        /// <inheritdoc/>
+        /// <summary>
+        /// Disposes the OsdpConnection instance.
+        /// </summary>
+        /// <remarks>
+        /// This method is responsible for releasing any resources used by the OsdpConnection instance. It calls the <see cref="Close"/> method to close the connection if it is open and sets
+        /// the <see cref="_disposedValue"/> field to true to indicate that the instance has been disposed.
+        /// </remarks>
         protected virtual void Dispose(bool disposing)
         {
             if (!_disposedValue)
@@ -62,104 +62,6 @@ namespace OSDP.Net.Connections
                 if (disposing)
                 {
                     Close();
-                }
-
-                _disposedValue = true;
-            }
-        }
-    }
-
-
-    /// <summary>
-    /// Base class for an OSDP server that listens for incoming connections
-    /// </summary>
-    public abstract class OsdpServer : IOsdpServer
-    {
-        private bool _disposedValue;
-        private readonly ConcurrentDictionary<Task, OsdpConnection> _connections = new();
-
-        /// <summary>
-        /// Creates a new instance of OsdpServer
-        /// </summary>
-        /// <param name="loggerFactory">Optional logger factory</param>
-        public OsdpServer(ILoggerFactory loggerFactory = null)
-        {
-            LoggerFactory = loggerFactory;
-            Logger = loggerFactory?.CreateLogger<OsdpServer>();
-        }
-
-        /// <inheritdoc/>
-        public bool IsRunning { get; protected set; }
-
-        /// <inheritdoc/>
-        public int ConnectionCount { get => _connections.Count; }
-
-        /// <summary>
-        /// Logger factory if one was specified at instantitation
-        /// </summary>
-        protected ILoggerFactory LoggerFactory { get; }
-
-        /// <summary>
-        /// Logger instance used by the server if a factory was specified at instantiation
-        /// </summary>
-        protected ILogger Logger { get; }
-
-        /// <inheritdoc/>
-        public abstract Task Start(Func<IOsdpConnection, Task> newConnectionHandler);
-
-        /// <inheritdoc/>
-        public virtual async Task Stop()
-        {
-            IsRunning = false;
-
-            Logger.LogDebug("Stopping OSDP Server connections...");
-
-            while (true)
-            {
-                var entries = _connections.ToArray();
-                if (entries.Length == 0) break;
-
-                await Task.WhenAll(entries.Select(item => item.Value.Close()));
-                await Task.WhenAll(entries.Select(x => x.Key));
-            }
-
-            Logger.LogDebug("OSDP Server STOPPED");
-        }
-
-        /// <inheritdoc/>
-        public void Dispose()
-        {
-            Dispose(true);
-            GC.SuppressFinalize(this);
-        }
-
-        /// <summary>
-        /// Intended to be called by a deriving class whenever it spins off a dedicated
-        /// listening loop task for a newly created OsdpConnection
-        /// </summary>
-        /// <param name="connection"></param>
-        /// <param name="task"></param>
-        protected void RegisterConnection(OsdpConnection connection, Task task)
-        {
-            Task.Run(async () =>
-            {
-                _connections.TryAdd(task, connection);
-                if (!IsRunning) await connection.Close();
-                Logger?.LogDebug("New OSDP connection opened - {}", _connections.Count);
-                await task;
-                _connections.TryRemove(task, out _);
-                Logger?.LogDebug("OSDP connection terminated - {}", _connections.Count);
-            });
-        }
-
-        /// <inheritdoc/>
-        protected virtual void Dispose(bool disposing)
-        {
-            if (!_disposedValue)
-            {
-                if (disposing)
-                {
-                    var _ = Stop();
                 }
 
                 _disposedValue = true;

--- a/src/OSDP.Net/Connections/OsdpConnection.cs
+++ b/src/OSDP.Net/Connections/OsdpConnection.cs
@@ -1,0 +1,129 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace OSDP.Net.Connections
+{
+    public abstract class OsdpConnection : IOsdpConnection
+    {
+        private bool _disposedValue;
+
+        protected OsdpConnection(int baudRate)
+        {
+            BaudRate = baudRate;
+        }   
+
+        public int BaudRate { get; }
+
+        public virtual bool IsOpen { get; protected set; }
+
+        public TimeSpan ReplyTimeout { get; set; } = TimeSpan.FromMilliseconds(200);
+
+        public abstract Task Close();
+        
+        public abstract Task Open();
+        
+        public abstract Task<int> ReadAsync(byte[] buffer, CancellationToken token);
+        
+        public abstract Task WriteAsync(byte[] buffer);
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    Close();
+                }
+
+                _disposedValue = true;
+            }
+        }
+    }
+
+
+    public abstract class OsdpServer : IOsdpServer
+    {
+        private bool _disposedValue;
+        private readonly ConcurrentDictionary<Task, OsdpConnection> _connections = new();
+        private readonly ILogger _logger;
+
+        public OsdpServer(ILoggerFactory loggerFactory = null)
+        {
+            _logger = loggerFactory?.CreateLogger<OsdpServer>();
+        }
+
+        public bool IsRunning { get; protected set; }
+
+        public int ConnectionCount { get => _connections.Count; }
+
+        public abstract Task Start(Func<IOsdpConnection, Task> newConnectionHandler);
+
+        public virtual async Task Stop()
+        {
+            IsRunning = false;
+
+            _logger.LogDebug("Stopping OSDP Server connections...");
+
+            while (true)
+            {
+                var entries = _connections.ToArray();
+                if (entries.Length == 0) break;
+
+                foreach (var item in entries)
+                {
+                    item.Value.Close();
+                }
+
+                await Task.WhenAll(entries.Select(x => x.Key));
+            }
+
+            _logger.LogDebug("OSDP Server STOPPED");
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void RegisterConnection(OsdpConnection connection, Task task)
+        {
+            Task.Run(async () =>
+            {
+                _logger?.LogDebug("New OSDP connection opened - {}", _connections.Count + 1);
+
+                _connections.TryAdd(task, connection);
+                if (!IsRunning) connection.Close();
+                await task;
+                _logger?.LogDebug("OSDP connection terminated - {}", _connections.Count - 1);
+                _connections.TryRemove(task, out _);
+            });
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    var _ = Stop();
+                }
+
+                _disposedValue = true;
+            }
+        }
+    }
+}

--- a/src/OSDP.Net/Connections/OsdpServer.cs
+++ b/src/OSDP.Net/Connections/OsdpServer.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace OSDP.Net.Connections;
+
+/// <summary>
+/// Base class for an OSDP server that listens for incoming connections
+/// </summary>
+public abstract class OsdpServer : IOsdpServer
+{
+    private bool _disposedValue;
+    private readonly ConcurrentDictionary<Task, OsdpConnection> _connections = new();
+
+    /// <summary>
+    /// Creates a new instance of OsdpServer
+    /// </summary>
+    /// <param name="loggerFactory">Optional logger factory</param>
+    public OsdpServer(ILoggerFactory loggerFactory = null)
+    {
+        LoggerFactory = loggerFactory;
+        Logger = loggerFactory?.CreateLogger<OsdpServer>();
+    }
+
+    /// <inheritdoc/>
+    public bool IsRunning { get; protected set; }
+
+    /// <inheritdoc/>
+    public int ConnectionCount { get => _connections.Count; }
+
+    /// <summary>
+    /// Logger factory if one was specified at instantitation
+    /// </summary>
+    protected ILoggerFactory LoggerFactory { get; }
+
+    /// <summary>
+    /// Logger instance used by the server if a factory was specified at instantiation
+    /// </summary>
+    protected ILogger Logger { get; }
+
+    /// <inheritdoc/>
+    public abstract Task Start(Func<IOsdpConnection, Task> newConnectionHandler);
+
+    /// <inheritdoc/>
+    public virtual async Task Stop()
+    {
+        IsRunning = false;
+
+        Logger.LogDebug("Stopping OSDP Server connections...");
+
+        while (true)
+        {
+            var entries = _connections.ToArray();
+            if (entries.Length == 0) break;
+
+            await Task.WhenAll(entries.Select(item => item.Value.Close()));
+            await Task.WhenAll(entries.Select(x => x.Key));
+        }
+
+        Logger.LogDebug("OSDP Server STOPPED");
+    }
+
+    /// <inheritdoc/>
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// Intended to be called by a deriving class whenever it spins off a dedicated
+    /// listening loop task for a newly created OsdpConnection
+    /// </summary>
+    /// <param name="connection"></param>
+    /// <param name="task"></param>
+    protected void RegisterConnection(OsdpConnection connection, Task task)
+    {
+        Task.Run(async () =>
+        {
+            _connections.TryAdd(task, connection);
+            if (!IsRunning) await connection.Close();
+            Logger?.LogDebug("New OSDP connection opened - {}", _connections.Count);
+            await task;
+            _connections.TryRemove(task, out _);
+            Logger?.LogDebug("OSDP connection terminated - {}", _connections.Count);
+        });
+    }
+
+
+    /// <summary>
+    /// Releases the resources used by the <see cref="OsdpServer"/> instance.
+    /// </summary>
+    /// <param name="disposing">A boolean value indicating whether the method is being called from the <see cref="OsdpServer.Dispose"/> method or the finalizer.</param>
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposedValue)
+        {
+            if (disposing)
+            {
+                var _ = Stop();
+            }
+
+            _disposedValue = true;
+        }
+    }
+}

--- a/src/OSDP.Net/Connections/SerialPortOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/SerialPortOsdpConnection.cs
@@ -128,13 +128,10 @@ namespace OSDP.Net.Connections
         {
             IsRunning = true;
 
-            Logger?.LogInformation("Opening {port} @ {baud} serial port...", _portName, _baudRate);
+            Logger?.LogInformation("Opening {Port} @ {Baud} serial port...", _portName, _baudRate);
 
             await OpenSerialPort(newConnectionHandler);
         }
-
-        /// <inheritdoc/>
-        public override Task Stop() => base.Stop();
 
         private async Task OpenSerialPort(Func<IOsdpConnection, Task> newConnectionHandler)
         {

--- a/src/OSDP.Net/Connections/SerialPortOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/SerialPortOsdpConnection.cs
@@ -13,6 +13,7 @@ namespace OSDP.Net.Connections
         private readonly string _portName;
         private readonly int _baudRate;
         private SerialPort _serialPort;
+        private bool _disposedValue;
 
         /// <summary>Initializes a new instance of the <see cref="T:OSDP.Net.Connections.SerialPortOsdpConnection" /> class.</summary>
         /// <param name="portName">Name of the port.</param>
@@ -97,6 +98,25 @@ namespace OSDP.Net.Connections
         public override string ToString()
         {
             return _portName;
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    Close();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/OSDP.Net/Connections/TcpClientOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/TcpClientOsdpConnection.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;

--- a/src/OSDP.Net/Connections/TcpClientOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/TcpClientOsdpConnection.cs
@@ -12,6 +12,7 @@ namespace OSDP.Net.Connections
         private readonly int _portNumber;
         private readonly string _server;
         private TcpClient _tcpClient;
+        private bool _disposedValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TcpClientOsdpConnection"/> class.
@@ -90,6 +91,26 @@ namespace OSDP.Net.Connections
         public override string ToString()
         {
             return $"{_server}:{_portNumber}";
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    Close();
+                }
+
+                _disposedValue = true;
+            }
+        }
+
+        /// <inheritdoc />
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
         }
     }
 }

--- a/src/OSDP.Net/Connections/TcpClientOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/TcpClientOsdpConnection.cs
@@ -39,7 +39,7 @@ namespace OSDP.Net.Connections
         /// <inheritdoc />
         public override async Task Open()
         {
-            Close();
+            await Close();
 
             _tcpClient = new TcpClient {NoDelay = true};
             await _tcpClient.ConnectAsync(_server, _portNumber);
@@ -58,7 +58,7 @@ namespace OSDP.Net.Connections
         /// <inheritdoc />
         public override async Task WriteAsync(byte[] buffer)
         {
-            if (!IsOpen) Open();
+            if (!IsOpen) await Open();
 
             var tcpClient = _tcpClient;
 

--- a/src/OSDP.Net/Connections/TcpServerOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/TcpServerOsdpConnection.cs
@@ -1,12 +1,20 @@
 using Microsoft.Extensions.Logging;
 using System;
+using System.IO;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace OSDP.Net.Connections
 {
-    /// <summary>Listens for a TCP/IP connection from a server.</summary>
+    /// <summary>
+    /// Initial implementation of TCP server OSDP connection which combines
+    /// the listener as well as the accepted connection in a single class.
+    /// 
+    /// The use of this class might be questionable as TCP/IP protocol 
+    /// inherently behaves differently enough that this class has some limitations
+    /// which have been addressed by TcpOsdpServer
+    /// </summary>
     public class TcpServerOsdpConnection : OsdpConnection
     {
         private readonly TcpListener _listener;
@@ -23,7 +31,7 @@ namespace OSDP.Net.Connections
         }
 
         /// <inheritdoc />
-        public bool IsOpen
+        public override bool IsOpen
         {
             get
             {
@@ -33,15 +41,12 @@ namespace OSDP.Net.Connections
         }
 
         /// <inheritdoc />
-        public TimeSpan ReplyTimeout { get; set; } = TimeSpan.FromMilliseconds(200);
-
-        /// <inheritdoc />
         public override async Task Open()
         {
             _listener.Start();
             var newTcpClient = await _listener.AcceptTcpClientAsync();
 
-            Close();
+            await Close();
 
             _tcpClient = newTcpClient;
         }
@@ -88,25 +93,42 @@ namespace OSDP.Net.Connections
 
     internal class TcpServerOsdpConnection2 : OsdpConnection
     {
+        private readonly ILogger _logger;
         private TcpClient _tcpClient;
         private NetworkStream _stream;
 
-        public TcpServerOsdpConnection2(TcpClient tcpClient, int baudRate) : base(baudRate)
+        public TcpServerOsdpConnection2(
+            TcpClient tcpClient, int baudRate, ILoggerFactory loggerFactory) : base(baudRate)
         {
             IsOpen = true;
             _tcpClient = tcpClient;
             _stream = tcpClient.GetStream();
+            _logger = loggerFactory?.CreateLogger<TcpServerOsdpConnection2>();
         }
 
         public override async Task<int> ReadAsync(byte[] buffer, CancellationToken token)
         {
             try
             {
-                return await _stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+                var bytes = await _stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+                if (bytes == 0) { IsOpen = false; }
+                return bytes;
             }
             catch (Exception ex) 
             {
-                if (!(ex is OperationCanceledException)) IsOpen = false;
+                if (ex is not OperationCanceledException && IsOpen)
+                {
+                    if (ex is IOException && ex.InnerException is SocketException)
+                    {
+                        _logger?.LogInformation("Error reading tcp stream: {err}", ex.Message);
+                    } 
+                    else
+                    {
+                        _logger?.LogWarning(ex, "Error reading tcp stream");
+                    }
+                    
+                    IsOpen = false;
+                }
                 return 0;
             }
         }
@@ -119,8 +141,11 @@ namespace OSDP.Net.Connections
             }
             catch (Exception ex)
             {
-                // TODO: Add logging?
-                IsOpen = false;
+                if (IsOpen)
+                {
+                    _logger?.LogWarning(ex, "Error writing tcp stream");
+                    IsOpen = false;
+                }
             }
         }
 
@@ -128,6 +153,7 @@ namespace OSDP.Net.Connections
 
         public override Task Close()
         {
+            IsOpen = false;
             _stream?.Dispose();
             _tcpClient?.Dispose();
             _stream = null;
@@ -137,12 +163,20 @@ namespace OSDP.Net.Connections
     }
 
 
+    /// <summary>
+    /// Implements TCP/IP OSDP server which listens for incoming connections
+    /// </summary>
     public class TcpOsdpServer : OsdpServer
     {
-        private TcpListener _listener;
-        private int _baudRate;
-        private bool _disposedValue;
+        private readonly TcpListener _listener;
+        private readonly int _baudRate;
 
+        /// <summary>
+        /// Creates a new instance of TcpOsdpServer
+        /// </summary>
+        /// <param name="portNumber">Port to listen on</param>
+        /// <param name="baudRate">Baud rate at which comms are expected to take place</param>
+        /// <param name="loggerFactory">Optional logger factory</param>
         public TcpOsdpServer(
             int portNumber, int baudRate, ILoggerFactory loggerFactory = null) : base(loggerFactory)
         {
@@ -150,12 +184,15 @@ namespace OSDP.Net.Connections
             _baudRate = baudRate;
         }
 
+        /// <inheritdoc/>
         public override Task Start(Func<IOsdpConnection, Task> newConnectionHandler)
         {
             if (IsRunning) return Task.CompletedTask;
 
             IsRunning = true;
             _listener.Start();
+
+            Logger?.LogInformation("Listening on {endpoint} for incoming connections...", _listener.LocalEndpoint);
 
             Task.Run(async () =>
             {
@@ -164,7 +201,7 @@ namespace OSDP.Net.Connections
                     var client = await _listener.AcceptTcpClientAsync();
                     if (client != null)
                     {
-                        var connection = new TcpServerOsdpConnection2(client, _baudRate);
+                        var connection = new TcpServerOsdpConnection2(client, _baudRate, LoggerFactory);
                         var task = newConnectionHandler(connection);
                         RegisterConnection(connection, task);
                     }
@@ -174,6 +211,7 @@ namespace OSDP.Net.Connections
             return Task.CompletedTask;
         }
 
+        /// <inheritdoc/>
         public override Task Stop()
         {
             IsRunning = false;

--- a/src/OSDP.Net/Connections/TcpServerOsdpConnection.cs
+++ b/src/OSDP.Net/Connections/TcpServerOsdpConnection.cs
@@ -10,6 +10,7 @@ namespace OSDP.Net.Connections
     {
         private readonly TcpListener _listener;
         private TcpClient _tcpClient;
+        private bool disposedValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TcpServerOsdpConnection"/> class.
@@ -84,6 +85,163 @@ namespace OSDP.Net.Connections
         public override string ToString()
         {
             return _listener?.LocalEndpoint.ToString();
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    Close();
+                }
+
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+
+
+    class TcpServerOsdpConnection2 : IOsdpConnection
+    {
+        private TcpClient _tcpClient;
+        private NetworkStream _stream;
+        private bool disposedValue;
+
+        public TcpServerOsdpConnection2(TcpClient tcpClient, int baudRate)
+        {
+            IsOpen = true;
+            BaudRate = baudRate;
+            _tcpClient = tcpClient;
+            _stream = tcpClient.GetStream();
+        }
+
+        public int BaudRate { get; }
+
+        public bool IsOpen { get; private set; }
+
+        public TimeSpan ReplyTimeout { get; set; } = TimeSpan.FromMilliseconds(200);
+
+        public async Task<int> ReadAsync(byte[] buffer, CancellationToken token)
+        {
+            try
+            {
+                return await _stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+            }
+            catch (Exception ex) 
+            {
+                if (!(ex is OperationCanceledException)) IsOpen = false;
+                return 0;
+            }
+        }
+
+        public async Task WriteAsync(byte[] buffer)
+        {
+            try
+            {
+                await _stream.WriteAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // TODO: Add logging?
+                IsOpen = false;
+            }
+        }
+
+        public void Open() => throw new NotSupportedException();
+
+        public void Close() => Dispose();
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposedValue)
+            {
+                if (disposing)
+                {
+                    _stream.Dispose();
+                    _tcpClient.Dispose();
+                }
+
+                _stream = null;
+                _tcpClient = null;
+                disposedValue = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+    }
+
+
+    public class TcpOsdpServer : IOsdpServer
+    {
+        private TcpListener _listener;
+        private int _baudRate;
+        private bool _disposedValue;
+
+        public TcpOsdpServer(int portNumber, int baudRate)
+        {
+            _listener = TcpListener.Create(portNumber);
+            _baudRate = baudRate;
+        }
+
+        public bool IsRunning {get; private set;}
+
+        public void Start(Func<IOsdpConnection, Task> newConnectionHandler)
+        {
+            if (IsRunning) return;
+
+            IsRunning = true;
+            _listener.Start();
+
+            Task.Run(async () =>
+            {
+                while (IsRunning)
+                {
+                    var client = await _listener.AcceptTcpClientAsync();
+                    if (client != null)
+                    {
+                        TcpServerOsdpConnection2 connection = new(client, _baudRate);
+
+                        // Intentionally let this function spin off on its own so that the caller
+                        // can work with the connection and let it go on their own
+                        var _ = newConnectionHandler(connection);
+                    }
+                }
+            });
+        }
+
+        public void Stop()
+        {
+            IsRunning = false;
+            _listener.Stop();
+        }
+
+        public void Dispose() => Dispose(true);
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposedValue)
+            {
+                if (disposing)
+                {
+                    Stop();
+                }
+
+                _listener = null;
+                _disposedValue = true;
+            }
         }
     }
 }

--- a/src/OSDP.Net/Connections/TcpServerOsdpConnection2.cs
+++ b/src/OSDP.Net/Connections/TcpServerOsdpConnection2.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.IO;
+using System.Net.Sockets;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace OSDP.Net.Connections;
+
+internal sealed class TcpServerOsdpConnection2 : OsdpConnection
+{
+    private readonly ILogger _logger;
+    private TcpClient _tcpClient;
+    private NetworkStream _stream;
+
+    public TcpServerOsdpConnection2(
+        TcpClient tcpClient, int baudRate, ILoggerFactory loggerFactory) : base(baudRate)
+    {
+        IsOpen = true;
+        _tcpClient = tcpClient;
+        _stream = tcpClient.GetStream();
+        _logger = loggerFactory?.CreateLogger<TcpServerOsdpConnection2>();
+    }
+
+    public override async Task<int> ReadAsync(byte[] buffer, CancellationToken token)
+    {
+        try
+        {
+            var bytes = await _stream.ReadAsync(buffer, 0, buffer.Length, token).ConfigureAwait(false);
+            if (bytes == 0) { IsOpen = false; }
+            return bytes;
+        }
+        catch (Exception exception) 
+        {
+            if (exception is not OperationCanceledException && IsOpen)
+            {
+                if (exception is IOException && exception.InnerException is SocketException)
+                {
+                    _logger?.LogInformation("Error reading tcp stream: {ExceptionMessage}", exception.Message);
+                } 
+                else
+                {
+                    _logger?.LogWarning(exception, "Error reading tcp stream");
+                }
+                    
+                IsOpen = false;
+            }
+            return 0;
+        }
+    }
+
+    public override async Task WriteAsync(byte[] buffer)
+    {
+        try
+        {
+            await _stream.WriteAsync(buffer, 0, buffer.Length).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            if (IsOpen)
+            {
+                _logger?.LogWarning(ex, "Error writing tcp stream");
+                IsOpen = false;
+            }
+        }
+    }
+        
+    /// <inheritdoc />
+    public override Task Open() => throw new NotSupportedException();
+
+    public override Task Close()
+    {
+        IsOpen = false;
+        _stream?.Dispose();
+        _tcpClient?.Dispose();
+        _stream = null;
+        _tcpClient = null;
+        return Task.CompletedTask;
+    }
+}

--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -50,6 +50,7 @@ public class Device : IDisposable
     public bool IsConnected => _osdpServer?.ConnectionCount > 0 && (
         _lastValidReceivedCommand + TimeSpan.FromSeconds(8) >= DateTime.UtcNow);
 
+    /// <inheritdoc/>
     protected virtual void Dispose(bool disposing)
     {
         if (disposing)
@@ -90,7 +91,6 @@ public class Device : IDisposable
         }
         catch (Exception exception)
         {
-            // TODO: What about clean client disconnect? Let's make sure that one doesn't get reported as error.
             _logger?.LogError(exception, $"Unexpected exception in polling loop");
         }
         finally
@@ -371,12 +371,5 @@ public class Device : IDisposable
         _logger?.LogInformation("Unexpected Command: {CommandType}", commandType);
 
         return new Nak(ErrorCode.UnknownCommandCode);
-    }
-
-    /// <inheritdoc />
-    public void Dispose()
-    {
-        _cancellationTokenSource?.Dispose();
-        _listenerTask?.Dispose();
     }
 }

--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using OSDP.Net.Connections;
@@ -50,7 +48,12 @@ public class Device : IDisposable
     public bool IsConnected => _osdpServer?.ConnectionCount > 0 && (
         _lastValidReceivedCommand + TimeSpan.FromSeconds(8) >= DateTime.UtcNow);
 
-    /// <inheritdoc/>
+    /// <summary>
+    /// Disposes the Device instance.
+    /// </summary>
+    /// <remarks>
+    /// This method is responsible for releasing any resources used by the Device instance. 
+    /// </remarks>
     protected virtual void Dispose(bool disposing)
     {
         if (disposing)
@@ -65,8 +68,6 @@ public class Device : IDisposable
     /// <param name="server">The I/O server used for communication with the OSDP client.</param>
     public async void StartListening(IOsdpServer server)
     {
-        var cancellationTokenSource = new CancellationTokenSource();
-
         if (_osdpServer != null) return;
 
         _osdpServer = server;

--- a/src/OSDP.Net/Messages/OutgoingMessage.cs
+++ b/src/OSDP.Net/Messages/OutgoingMessage.cs
@@ -43,7 +43,7 @@ internal class OutgoingMessage : Message
         buffer[currentLength++] = Address;
         buffer[currentLength++] = (byte)(totalLength & 0xff);
         buffer[currentLength++] = (byte)((totalLength >> 8) & 0xff);
-        buffer[currentLength++] = ControlBlock.ControlByte;
+        buffer[currentLength++] = (byte)(ControlBlock.ControlByte | (isSecurityBlockPresent ? 0x08 : 0x00));
 
         if (isSecurityBlockPresent)
         {
@@ -101,4 +101,15 @@ internal class OutgoingMessage : Message
     {
         return PayloadData.BuildData();
     }
+}
+
+
+internal class OutgoingReply : OutgoingMessage
+{
+    internal OutgoingReply(IncomingMessage command, PayloadData replyPayload) :
+        base((byte)(command.Address | 0x80), command.ControlBlock, replyPayload)
+    {
+        Command = command;
+    }
+    internal IncomingMessage Command { get; }
 }

--- a/src/OSDP.Net/Messages/SecureChannel/PdMessageSecureChannel.cs
+++ b/src/OSDP.Net/Messages/SecureChannel/PdMessageSecureChannel.cs
@@ -74,8 +74,7 @@ namespace OSDP.Net.Messages.SecureChannel
                 throw new TimeoutException("Timeout waiting for command of reply message");
             }
 
-            // TODO: best way to log?
-            Debug.WriteLine("Incoming: " + BitConverter.ToString(commandBuffer.ToArray()));
+            Logger?.LogDebug("Incoming: " + BitConverter.ToString(commandBuffer.ToArray()));
 
             var command = new IncomingMessage(commandBuffer.ToArray().AsSpan(), this);
 
@@ -90,6 +89,8 @@ namespace OSDP.Net.Messages.SecureChannel
 
         internal async Task SendReply(OutgoingMessage reply)
         {
+            Logger?.LogInformation("Sending Reply: {reply}", Enum.GetName(typeof(ReplyType), reply.PayloadData.Code));
+
             await _connection.WriteAsync(reply.BuildMessage(this));
         }
 
@@ -105,7 +106,7 @@ namespace OSDP.Net.Messages.SecureChannel
 
             if (reply == null) return false;
 
-            await SendReply(new OutgoingMessage(           (byte)(command.Address | 0x80), command.ControlBlock, reply));
+            await SendReply(new OutgoingMessage((byte)(command.Address | 0x80), command.ControlBlock, reply));
 
             if (command.Type == (byte)CommandType.ServerCryptogram)
             {

--- a/src/OSDP.Net/Messages/SecureChannel/PdMessageSecureChannel.cs
+++ b/src/OSDP.Net/Messages/SecureChannel/PdMessageSecureChannel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.ObjectModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -79,7 +78,7 @@ namespace OSDP.Net.Messages.SecureChannel
             if (command.Type != (byte)CommandType.Poll)
             {
                 Logger?.LogInformation("Received Command: {CommandType}", Enum.GetName(typeof(CommandType), command.Type));
-                Logger?.LogDebug("Incoming: {data}", BitConverter.ToString(commandBuffer.ToArray()));
+                Logger?.LogDebug("Incoming: {Data}", BitConverter.ToString(commandBuffer.ToArray()));
             }
 
             var commandHandled = await HandleCommand(command);
@@ -92,8 +91,8 @@ namespace OSDP.Net.Messages.SecureChannel
 
             if (reply.Command.Type != (byte)CommandType.Poll)
             {
-                Logger?.LogInformation("Sending Reply: {reply}", Enum.GetName(typeof(ReplyType), reply.PayloadData.Code));
-                Logger?.LogDebug("Outgoing: {data}", BitConverter.ToString(replyBuffer));
+                Logger?.LogInformation("Sending Reply: {Reply}", Enum.GetName(typeof(ReplyType), reply.PayloadData.Code));
+                Logger?.LogDebug("Outgoing: {Data}", BitConverter.ToString(replyBuffer));
             }
 
             await _connection.WriteAsync(replyBuffer);

--- a/src/samples/CardReader/CardReader.csproj
+++ b/src/samples/CardReader/CardReader.csproj
@@ -13,8 +13,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/samples/CardReader/MySampleDevice.cs
+++ b/src/samples/CardReader/MySampleDevice.cs
@@ -11,7 +11,7 @@ internal class MySampleDevice : Device
 
     protected override PayloadData HandleIdReport()
     {
-        return new DeviceIdentification([0x00, 0x00, 0x00], 0, 1, 0, 0, 0, 0);
+        return new DeviceIdentification([0x01, 0x02, 0x03], 4, 5, 6, 7, 8, 9);
     }
 
     protected override PayloadData HandleDeviceCapabilities()

--- a/src/samples/CardReader/MySampleDevice.cs
+++ b/src/samples/CardReader/MySampleDevice.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using OSDP.Net;
 using OSDP.Net.Model;
 using OSDP.Net.Model.ReplyData;
@@ -6,6 +7,8 @@ namespace CardReader;
 
 internal class MySampleDevice : Device
 {
+    public MySampleDevice(ILoggerFactory loggerFactory) : base(loggerFactory) { }
+
     protected override PayloadData HandleIdReport()
     {
         return new DeviceIdentification([0x00, 0x00, 0x00], 0, 1, 0, 0, 0, 0);

--- a/src/samples/CardReader/Program.cs
+++ b/src/samples/CardReader/Program.cs
@@ -11,8 +11,7 @@ internal class Program
 {
     private static async Task Main()
     {
-        var builder = new ConfigurationBuilder().AddJsonFile("appsettings.json", true, true);
-        var config = builder.Build();
+        var config = new ConfigurationBuilder().AddJsonFile("appsettings.json", true, true).Build();
         var osdpSection = config.GetSection("OSDP");
 
         var portName = osdpSection["PortName"];
@@ -22,19 +21,16 @@ internal class Program
         var loggerFactory = LoggerFactory.Create(builder =>
         {
             builder
-                .AddConsole(options =>
-                {
-                })
+                .AddConsole()
                 .SetMinimumLevel(LogLevel.Warning)
                 .AddFilter("CardReader.Program", LogLevel.Information)
                 .AddFilter("OSDP.Net", LogLevel.Debug);
         });
-        var logger = loggerFactory.CreateLogger<Program>();
 
-        // var comms = new TcpOsdpServer(5000, baudRate, loggerFactory);
-        var comms = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
+        // var communications = new TcpOsdpServer(5000, baudRate, loggerFactory);
+        var communications = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
         using var device = new MySampleDevice(loggerFactory);
-        device.StartListening(comms);
+        device.StartListening(communications);
 
         await Task.Run(async () =>
         {

--- a/src/samples/CardReader/Program.cs
+++ b/src/samples/CardReader/Program.cs
@@ -32,7 +32,8 @@ internal class Program
         var logger = loggerFactory.CreateLogger<Program>();
 
         // var connection = new SerialPortOsdpConnection(portName, baudRate);
-        var comms = new TcpOsdpServer(5000, baudRate);
+        var comms = new TcpOsdpServer(5000, baudRate, loggerFactory);
+        // var comms = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
         using var device = new MySampleDevice(loggerFactory);
         device.StartListening(comms);
 
@@ -64,7 +65,7 @@ internal class Program
         Console.WriteLine("Press any key to finish the program.");
         Console.ReadKey();
 
-        device.StopListening();
+        await device.StopListening();
     }
 
     private static string BigIntegerToBinaryString(BigInteger value)

--- a/src/samples/CardReader/Program.cs
+++ b/src/samples/CardReader/Program.cs
@@ -31,13 +31,10 @@ internal class Program
         });
         var logger = loggerFactory.CreateLogger<Program>();
 
-        // var connection = new SerialPortOsdpConnection(portName, baudRate);
-        var comms = new TcpOsdpServer(5000, baudRate, loggerFactory);
-        // var comms = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
+        // var comms = new TcpOsdpServer(5000, baudRate, loggerFactory);
+        var comms = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
         using var device = new MySampleDevice(loggerFactory);
         device.StartListening(comms);
-
-        logger.LogInformation("OSDP PD Device is listening on port 5000...");
 
         await Task.Run(async () =>
         {

--- a/src/samples/CardReader/appsettings.json
+++ b/src/samples/CardReader/appsettings.json
@@ -1,6 +1,6 @@
 {
   "OSDP": {
-    "PortName": "/dev/ttyUSB0",
+    "PortName": "COM4",
     "BaudRate": "9600",
     "DeviceAddress": "0"
   }


### PR DESCRIPTION
  - Logger within Device class and the sample CardReader project
  - IDisposable interface on IOsdpConnection interface and all
    classes that derive from it
  - IOsdpServer interface which works with Serial AND TCP to be
    used by the device that is intended to open a listening side
    of a network connection and wait for the client to connect to
    it
  - Fixed establishing secure channel between PD and ACU
  - Added logging within Device class to help troublshoot stuff
  - Make IOsdpConnection interface fully async so that the ability
    is there when it is needed (i.e. tcp) and implementation still
    has the option of being fully sync and simply returning
    Task.CompletedTask when not needed (i.e. serial)
- Cleaned up all build warnings
- Cleaned up runtime error/warning logs
- Make Serial PD connection more resilient such that if it connects
  to a port that already has some data, the timeout won't cause 
  entire PD to permanently fail, but rather it will handle the error
  and recreate serial comm port connection (will also handle any
  other transient comm error via same logic)