### PR TITLE
GH158 & GH156 - PD secure key and osdp_KeySet

### DIFF
--- a/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
+++ b/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
@@ -1,0 +1,328 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OSDP.Net.Connections;
+using OSDP.Net.Model;
+using OSDP.Net.Model.CommandData;
+using OSDP.Net.Model.ReplyData;
+using DeviceCapabilities = OSDP.Net.Model.ReplyData.DeviceCapabilities;
+
+namespace OSDP.Net.Tests.IntegrationTests;
+
+
+//
+// NOTE: Majority of naming/structure in this file is very much a work-in-progress
+// and will be updated if we continue to build out a set of integration tests
+//
+// Presently this is a POC experiment to see how far we can take a test harness that
+// instantiates the ControlPanel (ACU) and a Device (PD) and establishes a set of
+// full end-to-end test scenarios between those components.
+//
+// If/when this continues to evolve, we'll need refactor the tests into a set of helpers
+// such that device setup/teardown code isn't repeated. And then a helper or two will 
+// need to be added to make it easy/clear to write assertions which wait for certain
+// events to occur (e.g. device came online).
+//
+// NOTE: Integration tests by nature are SLOWER than unit tests. Hence why they are 
+// tagged with "Integration" category as we might want to exclude them at some point if
+// the default PR test checks become too slow. There's only 5 tests here and they already
+// take 25 sec to run. Then again, this might also highlight improvement opportunity
+// in...
+//   - ControlPanel and/or Device connection establishment logic. 
+//   - ControlPanel's ability to signal when connection failed (right now we know when
+//     it succeeds but if it doesn't we just keep trying until 10 sec timeout).
+//
+
+
+
+[TestFixture]
+[Category("Integration")]
+public class PeripheryDeviceTest
+{
+    private ILoggerFactory _loggerFactory;
+
+    [SetUp]
+    public void Setup()
+    {
+        // Each test gets spun up with its own console capture so we have to create
+        // a new logger factory instance for every single test. Otherwise, the test runner
+        // isn't able to associate stdout output with the particular test
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder
+                .AddFilter("OSDP.Net", LogLevel.Debug)
+                .SetMinimumLevel(LogLevel.Debug)
+                .AddConsole();
+        });
+    }
+
+    [TearDown]
+    public void Teardown() 
+    {
+        _loggerFactory?.Dispose();
+    }
+
+    [Test]
+    public async Task TestEstablishingConnectionWithNonDefaultSecurityKey()
+    {
+        var securityKey = new byte[] { 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x1, 0x2, 0x3, 0x4, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf };
+        var deviceConfig = new DeviceConfiguration() { SecurityKey = securityKey };
+        using var device = new TestDevice(deviceConfig, _loggerFactory);
+        var panel = new ControlPanel(_loggerFactory.CreateLogger<ControlPanel>());
+        var tcsDeviceOnline = new TaskCompletionSource<bool>();
+
+        try
+        {
+            device.StartListening(new TcpOsdpServer(6000, 9600, _loggerFactory));
+
+            var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
+
+            panel.ConnectionStatusChanged += (sender, e) =>
+            {
+                TestContext.WriteLine($"Received event: {e}");
+
+                if (e.ConnectionId == connectionId && e.IsConnected)
+                {
+                    tcsDeviceOnline.TrySetResult(true);
+                }
+            };
+
+            panel.AddDevice(connectionId, 0, true, true, securityKey);
+
+            if (await Task.WhenAny(tcsDeviceOnline.Task, Task.Delay(10000)) != tcsDeviceOnline.Task)
+            {
+                Assert.Fail("Timeout waiting for connection to come online");
+            }
+        }
+        finally
+        {
+            await panel.Shutdown();
+            await device.StopListening();
+        }
+    }
+
+    [Test]
+    public async Task TestEstablishingConnectionWhenScBkIsSameAsDefaultKey()
+    {
+        var securityKey = "0123456789:;<=>?"u8.ToArray();
+        var deviceConfig = new DeviceConfiguration() { SecurityKey = securityKey };
+        using var device = new TestDevice(deviceConfig, _loggerFactory);
+        var panel = new ControlPanel(_loggerFactory.CreateLogger<ControlPanel>());
+        var tcsDeviceOnline = new TaskCompletionSource<bool>();
+
+        try
+        {
+            device.StartListening(new TcpOsdpServer(6000, 9600, _loggerFactory));
+
+            var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
+
+            panel.ConnectionStatusChanged += (sender, e) =>
+            {
+                TestContext.WriteLine($"Received event: {e}");
+
+                if (e.ConnectionId == connectionId && e.IsConnected)
+                {
+                    tcsDeviceOnline.TrySetResult(true);
+                }
+            };
+
+            panel.AddDevice(connectionId, 0, true, true, securityKey);
+
+            if (await Task.WhenAny(tcsDeviceOnline.Task, Task.Delay(10000)) != tcsDeviceOnline.Task)
+            {
+                Assert.Fail("Timeout waiting for connection to come online");
+            }
+        }
+        finally
+        {
+            await panel.Shutdown();
+            await device.StopListening();
+        }
+    }
+
+    [Test]
+    public async Task VerifyDefaultKeyIsRejectedWhenDefaultNotAllowed()
+    {
+        // PD using non-default key
+        var securityKey = new byte[] { 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x1, 0x2, 0x3, 0x4, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf };
+        var deviceConfig = new DeviceConfiguration() { SecurityKey = securityKey, DefaultSecurityKeyAllowed = false };
+        using var device = new TestDevice(deviceConfig, _loggerFactory);
+
+        var panel = new ControlPanel(_loggerFactory.CreateLogger<ControlPanel>());
+        var tcsDeviceOnline = new TaskCompletionSource<bool>();
+
+        try
+        {
+            device.StartListening(new TcpOsdpServer(6000, 9600, _loggerFactory));
+
+            var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
+
+            panel.ConnectionStatusChanged += (sender, e) =>
+            {
+                TestContext.WriteLine($"Received event: {e}");
+
+                if (e.ConnectionId == connectionId && e.IsConnected)
+                {
+                    tcsDeviceOnline.TrySetResult(true);
+                }
+            };
+
+            // Add device with a default key - this shouldn't connect
+            panel.AddDevice(connectionId, 0, true, true);
+
+            if (await Task.WhenAny(tcsDeviceOnline.Task, Task.Delay(10000)) == tcsDeviceOnline.Task)
+            {
+                Assert.Fail("This connections was expected to fail but IT DID NOT!!");
+            }
+        }
+        finally
+        {
+            await panel.Shutdown();
+            await device.StopListening();
+        }
+    }
+
+    [Test]
+    public async Task VerifyDefaultKeyWorksWhenConfigAllowsItsUse()
+    {
+        // PD using non-default key but ALSO allows default key
+        var securityKey = new byte[] { 0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x1, 0x2, 0x3, 0x4, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf };
+        var deviceConfig = new DeviceConfiguration() { SecurityKey = securityKey, DefaultSecurityKeyAllowed = true };
+        using var device = new TestDevice(deviceConfig, _loggerFactory);
+
+        var panel = new ControlPanel(_loggerFactory.CreateLogger<ControlPanel>());
+        var tcsDeviceOnline = new TaskCompletionSource<bool>();
+
+        try
+        {
+            device.StartListening(new TcpOsdpServer(6000, 9600, _loggerFactory));
+
+            var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
+
+            panel.ConnectionStatusChanged += (sender, e) =>
+            {
+                TestContext.WriteLine($"Received event: {e}");
+
+                if (e.ConnectionId == connectionId && e.IsConnected)
+                {
+                    tcsDeviceOnline.TrySetResult(true);
+                }
+            };
+
+            // Add device with a default key
+            panel.AddDevice(connectionId, 0, true, true);
+
+            if (await Task.WhenAny(tcsDeviceOnline.Task, Task.Delay(10000)) != tcsDeviceOnline.Task)
+            {
+                Assert.Fail("Timeout waiting for connection to come online");
+            }
+        }
+        finally
+        {
+            await panel.Shutdown();
+            await device.StopListening();
+        }
+    }
+
+
+    [Test]
+    public async Task DeviceHandlesOsdpKeySetCommand()
+    {
+        var deviceConfig = new DeviceConfiguration();
+        using var device = new TestDevice(deviceConfig, _loggerFactory);
+        var panel = new ControlPanel(_loggerFactory.CreateLogger<ControlPanel>());
+        var tcsDeviceOnline = new TaskCompletionSource<bool>();
+
+        try
+        {
+            device.StartListening(new TcpOsdpServer(6000, 9600, _loggerFactory));
+
+            var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
+
+            panel.ConnectionStatusChanged += (sender, e) =>
+            {
+                TestContext.WriteLine($"Received event: {e}");
+
+                if (e.ConnectionId == connectionId && e.IsConnected)
+                {
+                    tcsDeviceOnline.TrySetResult(true);
+                }
+            };
+
+            panel.AddDevice(connectionId, 0, true, true);
+
+            // In my tests it takes solid 2 sec for connection to get signalled ONLINE. Therefore,
+            // with some margin of safety we are using a 10sec timeout here to make sure tests don't 
+            // get permanently stuck but also have enough time for connection magic to happen. 
+            // 2 sec does seem awfully slow though
+            if (await Task.WhenAny(tcsDeviceOnline.Task, Task.Delay(10000)) != tcsDeviceOnline.Task)
+            {
+                Assert.Fail("Timeout waiting for connection to come online");
+            }
+
+            var newKey = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf };
+            var result = await panel.EncryptionKeySet(connectionId, 0, 
+                new EncryptionKeyConfiguration(KeyType.SecureChannelBaseKey, newKey));
+            Assert.True(result);
+
+            await AssertPanelToDeviceCommsAreHealthy(panel, connectionId);
+
+            panel.RemoveDevice(connectionId, 0);
+            tcsDeviceOnline = new TaskCompletionSource<bool>();
+            panel.AddDevice(connectionId, 0, true, true, newKey);
+
+            if (await Task.WhenAny(tcsDeviceOnline.Task, Task.Delay(10000)) != tcsDeviceOnline.Task)
+            {
+                Assert.Fail("Timeout waiting for connection to come online");
+            }
+        }
+        finally
+        {
+            await panel.Shutdown();
+            await device.StopListening();
+        }
+    }
+
+    private async Task AssertPanelToDeviceCommsAreHealthy(ControlPanel panel, Guid connectionId)
+    {
+        var capabilities = await panel.DeviceCapabilities(connectionId, 0);
+        Assert.NotNull(capabilities);
+    }
+}
+
+
+internal class TestDevice : Device
+{
+    public TestDevice(DeviceConfiguration config, ILoggerFactory loggerFactory)
+        : base(config, loggerFactory) { }
+
+    protected override PayloadData HandleIdReport()
+    {
+        return new DeviceIdentification([0x01, 0x02, 0x03], 4, 5, 6, 7, 8, 9);
+    }
+
+    protected override PayloadData HandleDeviceCapabilities()
+    {
+        var deviceCapabilities = new DeviceCapabilities(new[]
+        {
+            new DeviceCapability(CapabilityFunction.CardDataFormat, 1, 0),
+            new DeviceCapability(CapabilityFunction.ReaderLEDControl, 1, 0),
+            new DeviceCapability(CapabilityFunction.ReaderTextOutput, 0, 0),
+            new DeviceCapability(CapabilityFunction.CheckCharacterSupport, 1, 0),
+            new DeviceCapability(CapabilityFunction.CommunicationSecurity, 1, 1),
+            new DeviceCapability(CapabilityFunction.ReceiveBufferSize, 0, 1),
+            new DeviceCapability(CapabilityFunction.OSDPVersion, 2, 0)
+        });
+
+        return deviceCapabilities;
+    }
+
+    protected override PayloadData HandleKeySettings(EncryptionKeyConfiguration commandPayload)
+    {
+        return new Ack();
+    }
+}

--- a/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
+++ b/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -81,7 +78,7 @@ public class PeripheryDeviceTest
 
             var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
 
-            panel.ConnectionStatusChanged += (sender, e) =>
+            panel.ConnectionStatusChanged += (_, e) =>
             {
                 TestContext.WriteLine($"Received event: {e}");
 
@@ -120,7 +117,7 @@ public class PeripheryDeviceTest
 
             var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
 
-            panel.ConnectionStatusChanged += (sender, e) =>
+            panel.ConnectionStatusChanged += (_, e) =>
             {
                 TestContext.WriteLine($"Received event: {e}");
 
@@ -161,7 +158,7 @@ public class PeripheryDeviceTest
 
             var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
 
-            panel.ConnectionStatusChanged += (sender, e) =>
+            panel.ConnectionStatusChanged += (_, e) =>
             {
                 TestContext.WriteLine($"Received event: {e}");
 
@@ -203,7 +200,7 @@ public class PeripheryDeviceTest
 
             var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
 
-            panel.ConnectionStatusChanged += (sender, e) =>
+            panel.ConnectionStatusChanged += (_, e) =>
             {
                 TestContext.WriteLine($"Received event: {e}");
 
@@ -243,12 +240,13 @@ public class PeripheryDeviceTest
 
             var connectionId = panel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, 9600));
 
-            panel.ConnectionStatusChanged += (sender, e) =>
+            panel.ConnectionStatusChanged += (_, e) =>
             {
                 TestContext.WriteLine($"Received event: {e}");
 
                 if (e.ConnectionId == connectionId && e.IsConnected)
                 {
+                    // ReSharper disable once AccessToModifiedClosure
                     tcsDeviceOnline.TrySetResult(true);
                 }
             };

--- a/src/OSDP.Net.Tests/Messages/SecureChannel/SecureContextTest.cs
+++ b/src/OSDP.Net.Tests/Messages/SecureChannel/SecureContextTest.cs
@@ -1,10 +1,5 @@
 ﻿using NUnit.Framework;
 using OSDP.Net.Messages.SecureChannel;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace OSDP.Net.Tests.Messages.SecureChannel
 {

--- a/src/OSDP.Net.Tests/Messages/SecureChannel/SecureContextTest.cs
+++ b/src/OSDP.Net.Tests/Messages/SecureChannel/SecureContextTest.cs
@@ -1,0 +1,29 @@
+﻿using NUnit.Framework;
+using OSDP.Net.Messages.SecureChannel;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OSDP.Net.Tests.Messages.SecureChannel
+{
+    [TestFixture]
+    public class SecureContextTest
+    {
+        [Test]
+        public void IsDefaultKeyProperlySet()
+        {
+            var defaultKey = "0123456789:;<=>?"u8.ToArray();
+            var nonDefaultKey = "0123-Bob-9:;<=>?"u8.ToArray();
+
+            Assert.Multiple(() =>
+            {
+                Assert.True(new SecurityContext().IsUsingDefaultKey, "default constructor");
+                Assert.True(new SecurityContext(SecurityContext.DefaultKey).IsUsingDefaultKey, "with static def key");
+                Assert.True(new SecurityContext(defaultKey).IsUsingDefaultKey, "with local def key");
+                Assert.False(new SecurityContext(nonDefaultKey).IsUsingDefaultKey, "non-def key");
+            });
+        }
+    }
+}

--- a/src/OSDP.Net.Tests/OSDP.Net.Tests.csproj
+++ b/src/OSDP.Net.Tests/OSDP.Net.Tests.csproj
@@ -11,6 +11,8 @@
     <ItemGroup>
         <PackageReference Include="apache.log4net.Extensions.Logging" Version="2.0.0.12" />
         <PackageReference Include="log4net" Version="2.0.15" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
         <PackageReference Include="Microsoft.NETCore.Platforms" Version="7.0.4" />
         <PackageReference Include="Moq" Version="4.20.69" />
         <PackageReference Include="nunit" Version="3.13.3" />

--- a/src/OSDP.Net/Connections/OsdpServer.cs
+++ b/src/OSDP.Net/Connections/OsdpServer.cs
@@ -48,7 +48,7 @@ public abstract class OsdpServer : IOsdpServer
     {
         IsRunning = false;
 
-        Logger.LogDebug("Stopping OSDP Server connections...");
+        Logger?.LogDebug("Stopping OSDP Server connections...");
 
         while (true)
         {
@@ -59,7 +59,7 @@ public abstract class OsdpServer : IOsdpServer
             await Task.WhenAll(entries.Select(x => x.Key));
         }
 
-        Logger.LogDebug("OSDP Server STOPPED");
+        Logger?.LogDebug("OSDP Server STOPPED");
     }
 
     /// <inheritdoc/>

--- a/src/OSDP.Net/ControlPanel.cs
+++ b/src/OSDP.Net/ControlPanel.cs
@@ -1540,6 +1540,10 @@ namespace OSDP.Net
             /// Is the secure channel currently established
             /// </summary>
             public bool IsSecureChannelEstablished { get; }
+
+            /// <inheritdoc/>
+            public override string ToString() =>
+                $"{ConnectionId}:{Address} - Conn: {IsConnected}; Sec: {IsSecureChannelEstablished}";
         }
 
         /// <summary>

--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -23,7 +23,7 @@ public class Device : IDisposable
     private readonly ILogger _logger;
     private readonly ConcurrentQueue<PayloadData> _pendingPollReplies = new();
 
-    private volatile int _connectionContextCounter = 0;
+    private volatile int _connectionContextCounter;
     private DeviceConfiguration _deviceConfiguration;
     private IOsdpServer _osdpServer;
     private DateTime _lastValidReceivedCommand = DateTime.MinValue;

--- a/src/OSDP.Net/Messages/IncomingMessage.cs
+++ b/src/OSDP.Net/Messages/IncomingMessage.cs
@@ -151,7 +151,7 @@ namespace OSDP.Net.Messages
         /// <summary>
         /// Raw security block bytes
         /// </summary>
-        protected IEnumerable<byte> SecureBlockData { get; }
+        public byte[] SecureBlockData { get; }
 
         /// <inheritdoc/>
         protected override ReadOnlySpan<byte> Data() => Payload.ToArray();
@@ -180,6 +180,6 @@ namespace OSDP.Net.Messages
         /// Checks whether the secure cryptogram has been accepted.
         /// </summary>
         /// <returns>Returns true if the secure cryptogram has been accepted; otherwise, false.</returns>
-        public bool SecureCryptogramHasBeenAccepted() => Convert.ToByte(SecureBlockData.First()) == 0x01;
+        public bool SecureCryptogramHasBeenAccepted() => SecureBlockData[0] == 0x01;
     }
 }

--- a/src/OSDP.Net/Messages/SecureChannel/MessageSecureChannel.cs
+++ b/src/OSDP.Net/Messages/SecureChannel/MessageSecureChannel.cs
@@ -75,16 +75,10 @@ public abstract class MessageSecureChannel : IMessageSecureChannel
     }
 
     /// <inheritdoc />
-    public void ResetSecureChannelSession()
-    {
-        Context.CreateNewRandomNumber();
-    }
+    public void ResetSecureChannelSession() => Context.Reset();
 
     /// <inheritdoc />
-    public void Establish(byte[] rmac)
-    {
-        Context.Establish(rmac);
-    }
+    public void Establish(byte[] rmac) => Context.Establish(rmac);
 
     /// <summary>
     /// Generates a MAC for a command message

--- a/src/OSDP.Net/Messages/SecureChannel/SecurityContext.cs
+++ b/src/OSDP.Net/Messages/SecureChannel/SecurityContext.cs
@@ -12,7 +12,7 @@ namespace OSDP.Net.Messages.SecureChannel;
 /// </summary>
 public class SecurityContext
 {
-    private readonly byte[] _securityKey;
+    private byte[] _securityKey = DefaultKey;
 
     /// <summary>
     /// Represents the default key used in the security context.
@@ -22,14 +22,27 @@ public class SecurityContext
     /// <summary>
     /// Represents a security context for OSDP secure channel.
     /// </summary>
-    public SecurityContext(byte[] securityKey = null)
-    {
-        CreateNewRandomNumber();
-        IsUsingDefaultKey = securityKey != null && securityKey != DefaultKey;
-        _securityKey = securityKey ?? DefaultKey;
+    public SecurityContext(byte[] securityKey = null) => Reset(securityKey);
 
+    /// <summary>
+    /// Resets secure channel back to its initial state
+    /// </summary>
+    /// <param name="securityKey">
+    /// Can be optionally passed in to change the security key. If null, existing
+    /// key (or default one, SCBK-D) will be used if one was never specified
+    /// currently used
+    /// </param>
+    public void Reset(byte[] securityKey = null)
+    {
+        if (securityKey != null)
+        {
+            _securityKey = securityKey;
+        }
+
+        IsUsingDefaultKey = !(_securityKey != null && !_securityKey.SequenceEqual(DefaultKey));
         IsInitialized = false;
         IsSecurityEstablished = false;
+        new Random().NextBytes(ServerRandomNumber);
     }
 
     /// <summary>
@@ -193,17 +206,6 @@ public class SecurityContext
         IsInitialized = true;
     }
 
-    /// <summary>
-    /// Generates a new random number in the SecurityContext.
-    /// </summary>
-    internal void CreateNewRandomNumber()
-    {
-        // Todo - this might be needed
-        // IsInitialized = false;
-        // IsEstablished = false;
-        new Random().NextBytes(ServerRandomNumber);
-    }
-    
     internal void Establish(byte[] rmac)
     {
         RMac = rmac;

--- a/src/OSDP.Net/Model/ReplyData/InitialRMac.cs
+++ b/src/OSDP.Net/Model/ReplyData/InitialRMac.cs
@@ -12,12 +12,13 @@ namespace OSDP.Net.Model.ReplyData
         /// <summary>
         /// Creates a new instance of InitialRMac
         /// </summary>
-        /// <param name="rmac"></param>
-        /// <param name="isDefaultKey"></param>
-        public InitialRMac(byte[] rmac, bool isDefaultKey)
+        /// <param name="rmac">Initial R-MAC value to send back to the ACU</param>
+        /// <param name="serverCryptogramAccepted">Flag indicating whether or not 
+        /// server cryptogram was accepted by the PD</param>
+        public InitialRMac(byte[] rmac, bool serverCryptogramAccepted)
         {
             RMac = rmac;
-            IsDefaultKey = isDefaultKey;
+            ServerCryptogramAccepted = serverCryptogramAccepted;
         }
 
         /// <summary>
@@ -26,7 +27,7 @@ namespace OSDP.Net.Model.ReplyData
         /// </summary>
         public byte[] RMac { get; }
         
-        public bool IsDefaultKey { get; }
+        public bool ServerCryptogramAccepted { get; }
 
         /// <inheritdoc/>
         public override byte Code => (byte)ReplyType.InitialRMac;
@@ -41,7 +42,7 @@ namespace OSDP.Net.Model.ReplyData
             {
                 0x03,
                 (byte)SecurityBlockType.SecureConnectionSequenceStep2,
-                (byte)(IsDefaultKey ? 0x00 : 0x01)
+                (byte)(ServerCryptogramAccepted ? 0x01 : 0xff)
             };
         }
 

--- a/src/samples/CardReader/MySampleDevice.cs
+++ b/src/samples/CardReader/MySampleDevice.cs
@@ -7,7 +7,8 @@ namespace CardReader;
 
 internal class MySampleDevice : Device
 {
-    public MySampleDevice(ILoggerFactory loggerFactory) : base(loggerFactory) { }
+    public MySampleDevice(DeviceConfiguration config, ILoggerFactory loggerFactory)
+        : base(config, loggerFactory) { }
 
     protected override PayloadData HandleIdReport()
     {

--- a/src/samples/CardReader/Program.cs
+++ b/src/samples/CardReader/Program.cs
@@ -29,8 +29,11 @@ internal class Program
         });
 
         var deviceConfiguration = new DeviceConfiguration();
-        var communications = new TcpOsdpServer(5000, baudRate, loggerFactory);
-        // var communications = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
+        
+        // Replace commented out code for test reader to listen on TCP port rather than serial
+        //var communications = new TcpOsdpServer(5000, baudRate, loggerFactory);
+        var communications = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
+
         using var device = new MySampleDevice(deviceConfiguration, loggerFactory);
         device.StartListening(communications);
 

--- a/src/samples/CardReader/Program.cs
+++ b/src/samples/CardReader/Program.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using OSDP.Net;
 using OSDP.Net.Connections;
 using OSDP.Net.Model.ReplyData;
 
@@ -27,9 +28,10 @@ internal class Program
                 .AddFilter("OSDP.Net", LogLevel.Debug);
         });
 
-        // var communications = new TcpOsdpServer(5000, baudRate, loggerFactory);
-        var communications = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
-        using var device = new MySampleDevice(loggerFactory);
+        var deviceConfiguration = new DeviceConfiguration();
+        var communications = new TcpOsdpServer(5000, baudRate, loggerFactory);
+        // var communications = new SerialPortOsdpServer(portName, baudRate, loggerFactory);
+        using var device = new MySampleDevice(deviceConfiguration, loggerFactory);
         device.StartListening(communications);
 
         await Task.Run(async () =>


### PR DESCRIPTION
This commit introduces...

- ability to pass down security key into PD initialization
- we also added flag for PD to choose whether or not it will run in "installation mode" and allow default security key if it already has a different one set
- set of integration tests which test establishment of end-to-end communications (via TCP 6000, hardcoded for now) between PD and ACU sides of the library.
- And as a POC one of the tests verifies the behavior of osdp_KeySet command (others were added because I already found a bunch of edge conditions which had to be addressed)

Closes #158
Closes #156 - maybe? how much do we want to document outside of doc strings which are there now?