### PR TITLE
GH159 Implement PD osdp_ComSet command

### DIFF
--- a/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
+++ b/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
@@ -76,8 +76,8 @@ public class PeripheryDeviceTest
     [TearDown]
     public async Task Teardown() 
     {
-        await _targetPanel?.Shutdown();
-        await _targetDevice.StopListening();
+        await (_targetPanel?.Shutdown() ?? Task.CompletedTask);
+        await (_targetDevice?.StopListening() ?? Task.CompletedTask);
 
         _targetDevice?.Dispose();
         _loggerFactory?.Dispose();
@@ -119,7 +119,7 @@ public class PeripheryDeviceTest
         // Add device with a default key - this shouldn't connect
         AddDeviceToPanel();
 
-        await AssertPanelRemainsDisconnected(10000);
+        await AssertPanelRemainsDisconnected();
     }
 
     [Test]
@@ -234,7 +234,7 @@ public class PeripheryDeviceTest
             It.IsAny<object>(),
             It.IsAny<DeviceComSetUpdatedEventArgs>()), Times.Once);
 
-        var eventArgs = mockComSetUpdate.Invocations.First().Arguments[1] as DeviceComSetUpdatedEventArgs;
+        var eventArgs = (DeviceComSetUpdatedEventArgs)mockComSetUpdate.Invocations.First().Arguments[1];
         Assert.Multiple(() =>
         {
             Assert.AreEqual(0, eventArgs.OldAddress);
@@ -419,7 +419,7 @@ internal class TestDevice : Device
 
     protected override PayloadData HandleCommunicationSet(Net.Model.CommandData.CommunicationConfiguration commandPayload)
     {
-        var validBaudRates = new int[] { 9600, 19200, 115200 };
+        int[] validBaudRates = [9600, 19200, 115200];
         var newBaudRate = validBaudRates.Contains(commandPayload.BaudRate) ? commandPayload.BaudRate : validBaudRates[0];
 
         return new Net.Model.ReplyData.CommunicationConfiguration(commandPayload.Address, newBaudRate);

--- a/src/OSDP.Net.Tests/Model/ReplyData/CommunicationConfigurationTest.cs
+++ b/src/OSDP.Net.Tests/Model/ReplyData/CommunicationConfigurationTest.cs
@@ -1,0 +1,33 @@
+﻿using NUnit.Framework;
+using OSDP.Net.Model.ReplyData;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace OSDP.Net.Tests.Model.ReplyData
+{
+    [TestFixture]
+    public class CommunicationConfigurationTest
+    {
+        [Test]
+        public void ParseData()
+        {
+            var data = new byte[] { 0x19, 0x80, 0x25, 0x00, 0x00 };
+            var comConfig = CommunicationConfiguration.ParseData(data);
+
+            Assert.That(comConfig.Address, Is.EqualTo(25));
+            Assert.That(comConfig.BaudRate, Is.EqualTo(9600));
+        }
+
+        [Test]
+        public void BuildData()
+        {
+            var comConfig = new CommunicationConfiguration(25, 9600);
+            var buffer = comConfig.BuildData();
+
+            Assert.That(BitConverter.ToString(buffer), Is.EqualTo("19-80-25-00-00"));
+        }
+    }
+}

--- a/src/OSDP.Net.Tests/Model/ReplyData/CommunicationConfigurationTest.cs
+++ b/src/OSDP.Net.Tests/Model/ReplyData/CommunicationConfigurationTest.cs
@@ -1,10 +1,7 @@
 ﻿using NUnit.Framework;
 using OSDP.Net.Model.ReplyData;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 
 namespace OSDP.Net.Tests.Model.ReplyData
 {

--- a/src/OSDP.Net.Tests/Model/ReplyData/RawCardDataTest.cs
+++ b/src/OSDP.Net.Tests/Model/ReplyData/RawCardDataTest.cs
@@ -6,6 +6,7 @@ using OSDP.Net.Model.ReplyData;
 
 namespace OSDP.Net.Tests.Model.ReplyData
 {
+    [TestFixture]
     public class RawCardDataTest
     {
         [Test]

--- a/src/OSDP.Net/Connections/IOsdpServer.cs
+++ b/src/OSDP.Net/Connections/IOsdpServer.cs
@@ -11,6 +11,11 @@ namespace OSDP.Net.Connections;
 public interface IOsdpServer : IDisposable
 {
     /// <summary>
+    /// Baud rate for the current connection
+    /// </summary>
+    int BaudRate { get; }
+
+    /// <summary>
     /// Starts listening for incoming connections
     /// </summary>
     /// <param name="newConnectionHandler">Callback to be invoked whenever a new connection is accepted</param>

--- a/src/OSDP.Net/Connections/OsdpServer.cs
+++ b/src/OSDP.Net/Connections/OsdpServer.cs
@@ -17,11 +17,13 @@ public abstract class OsdpServer : IOsdpServer
     /// <summary>
     /// Creates a new instance of OsdpServer
     /// </summary>
+    /// <param name="baudRate"></param>
     /// <param name="loggerFactory">Optional logger factory</param>
-    protected OsdpServer(ILoggerFactory loggerFactory = null)
+    protected OsdpServer(int baudRate, ILoggerFactory loggerFactory = null)
     {
         LoggerFactory = loggerFactory;
         Logger = loggerFactory?.CreateLogger<OsdpServer>();
+        BaudRate = baudRate;
     }
 
     /// <inheritdoc/>
@@ -39,6 +41,9 @@ public abstract class OsdpServer : IOsdpServer
     /// Logger instance used by the server if a factory was specified at instantiation
     /// </summary>
     protected ILogger Logger { get; }
+
+    /// <inheritdoc/>
+    public int BaudRate { get; }
 
     /// <inheritdoc/>
     public abstract Task Start(Func<IOsdpConnection, Task> newConnectionHandler);

--- a/src/OSDP.Net/Connections/SerialPortOsdpServer.cs
+++ b/src/OSDP.Net/Connections/SerialPortOsdpServer.cs
@@ -16,7 +16,6 @@ namespace OSDP.Net.Connections;
 public class SerialPortOsdpServer : OsdpServer
 {
     private readonly string _portName;
-    private readonly int _baudRate;
 
     /// <summary>
     /// Creates a new instance of SerialPortOsdpServer
@@ -25,10 +24,9 @@ public class SerialPortOsdpServer : OsdpServer
     /// <param name="baudRate">Baud rate at which to communicate</param>
     /// <param name="loggerFactory">Optional logger factory</param>
     public SerialPortOsdpServer(
-        string portName, int baudRate, ILoggerFactory loggerFactory = null) : base(loggerFactory)
+        string portName, int baudRate, ILoggerFactory loggerFactory = null) : base(baudRate, loggerFactory)
     {
         _portName = portName;
-        _baudRate = baudRate;
     }
 
     /// <inheritdoc/>
@@ -36,14 +34,14 @@ public class SerialPortOsdpServer : OsdpServer
     {
         IsRunning = true;
 
-        Logger?.LogInformation("Opening {Port} @ {Baud} serial port...", _portName, _baudRate);
+        Logger?.LogInformation("Opening {Port} @ {Baud} serial port...", _portName, BaudRate);
 
         await OpenSerialPort(newConnectionHandler);
     }
 
     private async Task OpenSerialPort(Func<IOsdpConnection, Task> newConnectionHandler)
     {
-        var connection = new SerialPortOsdpConnection(_portName, _baudRate);
+        var connection = new SerialPortOsdpConnection(_portName, BaudRate);
         await connection.Open();
         var task = Task.Run(async () =>
         {

--- a/src/OSDP.Net/Connections/TcpOsdpServer.cs
+++ b/src/OSDP.Net/Connections/TcpOsdpServer.cs
@@ -11,7 +11,6 @@ namespace OSDP.Net.Connections;
 public class TcpOsdpServer : OsdpServer
 {
     private readonly TcpListener _listener;
-    private readonly int _baudRate;
 
     /// <summary>
     /// Creates a new instance of TcpOsdpServer
@@ -20,10 +19,9 @@ public class TcpOsdpServer : OsdpServer
     /// <param name="baudRate">Baud rate at which comms are expected to take place</param>
     /// <param name="loggerFactory">Optional logger factory</param>
     public TcpOsdpServer(
-        int portNumber, int baudRate, ILoggerFactory loggerFactory = null) : base(loggerFactory)
+        int portNumber, int baudRate, ILoggerFactory loggerFactory = null) : base(baudRate, loggerFactory)
     {
         _listener = TcpListener.Create(portNumber);
-        _baudRate = baudRate;
     }
 
     /// <inheritdoc/>
@@ -42,7 +40,7 @@ public class TcpOsdpServer : OsdpServer
             {
                 var client = await _listener.AcceptTcpClientAsync();
 
-                var connection = new TcpServerOsdpConnection2(client, _baudRate, LoggerFactory);
+                var connection = new TcpServerOsdpConnection2(client, BaudRate, LoggerFactory);
                 var task = newConnectionHandler(connection);
                 RegisterConnection(connection, task);
             }

--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -473,7 +473,7 @@ public class DeviceConfiguration : ICloneable
     /// <summary>
     /// Address the device is assigned 
     /// </summary>
-    public byte Address { get; set; } = 0;
+    public byte Address { get; set; }
 
     /// <summary>
     /// As described in D.8: Field Deployment and Configuration, this flag enables
@@ -481,7 +481,7 @@ public class DeviceConfiguration : ICloneable
     /// accepted even if a different key has already been set on the device. This flag
     /// should be used during setup and NOT for the operation of the device
     /// </summary>
-    public bool DefaultSecurityKeyAllowed { get; set; } = false;
+    public bool DefaultSecurityKeyAllowed { get; set; }
 
     /// <summary>
     /// Security Key if one was previously set via osdp_KeySet command or some

--- a/src/OSDP.Net/Messages/OutgoingMessage.cs
+++ b/src/OSDP.Net/Messages/OutgoingMessage.cs
@@ -43,7 +43,7 @@ internal class OutgoingMessage : Message
         buffer[currentLength++] = Address;
         buffer[currentLength++] = (byte)(totalLength & 0xff);
         buffer[currentLength++] = (byte)((totalLength >> 8) & 0xff);
-        buffer[currentLength++] = (byte)(ControlBlock.ControlByte | (isSecurityBlockPresent ? 0x08 : 0x00));
+        buffer[currentLength++] = (byte)((ControlBlock.ControlByte & 0x07) | (isSecurityBlockPresent ? 0x08 : 0x00));
 
         if (isSecurityBlockPresent)
         {

--- a/src/OSDP.Net/Messages/SecureChannel/PdMessageSecureChannel.cs
+++ b/src/OSDP.Net/Messages/SecureChannel/PdMessageSecureChannel.cs
@@ -62,6 +62,8 @@ namespace OSDP.Net.Messages.SecureChannel
 
         public bool DefaultKeyAllowed { get; set; } = false;
 
+        public byte Address { get; set; }
+
         public async Task<IncomingMessage> ReadNextCommand(CancellationToken cancellationToken = default)
         {
             var commandBuffer = new Collection<byte>();
@@ -115,6 +117,8 @@ namespace OSDP.Net.Messages.SecureChannel
 
         private async Task<bool> HandleCommand(IncomingMessage command)
         {
+            if (command.Address != Address) return true;
+
             var reply = (command.IsValidMac, (CommandType)command.Type) switch
             {
                 (false, _) => HandleInvalidMac(),

--- a/src/OSDP.Net/Model/ReplyData/CommunicationConfiguration.cs
+++ b/src/OSDP.Net/Model/ReplyData/CommunicationConfiguration.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Linq;
-using System.Security.Cryptography;
 using System.Text;
 using OSDP.Net.Messages;
 using OSDP.Net.Messages.SecureChannel;


### PR DESCRIPTION
This PR...
- Implements handling of osdp_ComSet on the PD side
- refactored integration tests into a set of helper init/cleanup methods
  that can be reused by multiple tests

Closes #159 