### PR TITLE
GH169: implement PD security modes

### DIFF
--- a/src/OSDP.Net.Tests/IntegrationTests/IntegrationTestFixtureBase.cs
+++ b/src/OSDP.Net.Tests/IntegrationTests/IntegrationTestFixtureBase.cs
@@ -1,0 +1,391 @@
+﻿using System;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using OSDP.Net.Connections;
+using OSDP.Net.Model;
+using OSDP.Net.Model.CommandData;
+using OSDP.Net.Model.ReplyData;
+using DeviceCapabilities = OSDP.Net.Model.ReplyData.DeviceCapabilities;
+using System.Linq;
+using Moq;
+using System.Collections.Concurrent;
+using OSDP.Net.Messages;
+using OSDP.Net.Messages.SecureChannel;
+
+namespace OSDP.Net.Tests.IntegrationTests;
+
+
+public sealed class IntegrationConsts
+{
+    public static readonly byte[] NonDefaultSCBK = [0xa, 0xb, 0xc, 0xd, 0xe, 0xf, 0x1, 0x2, 0x3, 0x4, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf];
+    public static readonly byte[] DefaultSCBK = "0123456789:;<=>?"u8.ToArray();
+    public const int DefaultTestBaud = 9600;
+    public const byte DefaultTestDeviceAddr = 0;
+}
+
+public class IntegrationTestFixtureBase
+{
+    protected ILoggerFactory _loggerFactory;
+    protected ControlPanel _targetPanel;
+    protected TestDevice _targetDevice;
+
+    protected byte _deviceAddress;
+    protected Guid _connectionId;
+
+    private TaskCompletionSource<bool> _deviceOnlineCompletionSource;
+    private ConcurrentQueue<EventCheckpoint> _eventCheckpoints = new();
+    private object _syncLock = new object();
+
+    protected ControlPanel TargetPanel { get => _targetPanel; }
+    protected TestDevice TargetDevice { get => _targetDevice; }
+
+    [SetUp]
+    public void Setup()
+    {
+        // Each test gets spun up with its own console capture so we have to create
+        // a new logger factory instance for every single test. Otherwise, the test runner
+        // isn't able to associate stdout output with the particular test
+        _loggerFactory = LoggerFactory.Create(builder =>
+        {
+            builder
+                .AddFilter("OSDP.Net", LogLevel.Debug)
+                .SetMinimumLevel(LogLevel.Debug)
+                .AddConsole();
+        });
+    }
+
+    [TearDown]
+    public async Task Teardown()
+    {
+        await (_targetPanel?.Shutdown() ?? Task.CompletedTask);
+        await (_targetDevice?.StopListening() ?? Task.CompletedTask);
+
+        _targetDevice?.Dispose();
+        _loggerFactory?.Dispose();
+    }
+
+    protected async Task InitTestTargets(
+        Action<DeviceConfiguration> configureDevice = null,
+        Action<PanelConfiguration> configurePanel = null)
+    {
+        InitTestTargetDevice(configureDevice, baudRate: IntegrationConsts.DefaultTestBaud);
+        await InitTestTargetPanel(configurePanel, baudRate: IntegrationConsts.DefaultTestBaud);
+    }
+
+    protected async Task InitTestTargetPanel(Action<PanelConfiguration> configurePanel = null, int baudRate = IntegrationConsts.DefaultTestBaud)
+    {
+        var panelConfiguration = new PanelConfiguration();
+        configurePanel?.Invoke(panelConfiguration);
+
+        _deviceOnlineCompletionSource = new TaskCompletionSource<bool>();
+
+        _targetPanel = new ControlPanel(
+            panelConfiguration.TestDeviceProxyNeeded ? new TestDeviceProxyFactory(panelConfiguration) : null,
+            _loggerFactory.CreateLogger<ControlPanel>());
+
+        _targetPanel.ConnectionStatusChanged += (_, e) =>
+        {
+            TestContext.WriteLine($"Received event: {e}");
+
+            if (e.ConnectionId != _connectionId) return;
+
+            lock (_syncLock)
+            {
+                TestEventType currentEventType;
+
+                if (e.IsConnected)
+                {
+                    _deviceOnlineCompletionSource.TrySetResult(true);
+                    currentEventType = TestEventType.ConnectionEstablished;
+                }
+                else
+                {
+                    currentEventType = TestEventType.ConnectionLost;
+                    if (_deviceOnlineCompletionSource.Task.IsCompleted)
+                    {
+                        _deviceOnlineCompletionSource = new TaskCompletionSource<bool>();
+                    }
+                }
+
+                if (_eventCheckpoints.TryPeek(out var checkpoint) && checkpoint.EventType == currentEventType)
+                {
+                    _eventCheckpoints.TryDequeue(out var _);
+                    checkpoint.Tcs.TrySetResult(true);
+                }
+            }
+        };
+
+        await RestartTargetPanelConnection(baudRate);
+    }
+
+    protected async Task RestartTargetPanelConnection(int baudRate = IntegrationConsts.DefaultTestBaud)
+    {
+        if (_connectionId != Guid.Empty)
+        {
+            await _targetPanel.StopConnection(_connectionId);
+        }
+
+
+        _connectionId = _targetPanel.StartConnection(new TcpClientOsdpConnection("localhost", 6000, baudRate));
+    }
+
+    protected void InitTestTargetDevice(
+        Action<DeviceConfiguration> configureDevice = null, int baudRate = IntegrationConsts.DefaultTestBaud)
+    {
+        var deviceConfig = new DeviceConfiguration() { Address = IntegrationConsts.DefaultTestDeviceAddr };
+        configureDevice?.Invoke(deviceConfig);
+
+        _deviceAddress = deviceConfig.Address;
+
+        _targetDevice = new TestDevice(deviceConfig, _loggerFactory);
+        _targetDevice.StartListening(new TcpOsdpServer(6000, baudRate, _loggerFactory));
+    }
+
+    protected void AddDeviceToPanel(
+        byte[] securityKey = null, byte? address = null, bool useSecureChannel = true, bool useCrc = true)
+    {
+        if (address != null)
+        {
+            _deviceAddress = address.Value;
+        }
+
+        _deviceOnlineCompletionSource = new TaskCompletionSource<bool>();
+        _targetPanel.AddDevice(_connectionId, _deviceAddress, useCrc, useSecureChannel, securityKey);
+    }
+
+    protected void RemoveDeviceFromPanel()
+    {
+        _targetPanel.RemoveDevice(_connectionId, _deviceAddress);
+    }
+
+    protected async Task WaitForDeviceOnlineStatus(int timeout = 10000)
+    {
+        var onlineTask = _deviceOnlineCompletionSource.Task;
+        if (await Task.WhenAny(onlineTask, Task.Delay(timeout)) != onlineTask)
+        {
+            Assert.Fail("Timeout waiting for device connection to come online");
+        }
+    }
+
+    protected async Task AssertPanelRemainsDisconnected(int timeout = 10000)
+    {
+        var onlineTask = _deviceOnlineCompletionSource.Task;
+        if (await Task.WhenAny(onlineTask, Task.Delay(timeout)) == onlineTask)
+        {
+            Assert.Fail("This connections was expected to fail but IT DID NOT!!");
+        }
+    }
+
+    protected async Task AssertPanelToDeviceCommsAreHealthy()
+    {
+        var capabilities = await _targetPanel.DeviceCapabilities(_connectionId, _deviceAddress);
+        Assert.NotNull(capabilities);
+    }
+
+    protected async Task SetupCheckpointForExpectedTestEvent(TestEventType eventType, int timeout = 10000)
+    {
+        TaskCompletionSource<bool> tcs = new();
+
+        _eventCheckpoints.Enqueue(new EventCheckpoint() { EventType = eventType, Tcs = tcs });
+
+        var result = await Task.WhenAny(tcs.Task, Task.Delay(timeout));
+        if (result != tcs.Task)
+        {
+            Assert.Fail($"Timeout waiting for event checkpoint '{eventType}'");
+        }
+    }
+
+    protected TestCommand BuildTestCommand(CommandType type)
+    {
+        TestCommand command = type switch
+        {
+            CommandType.IdReport => new IdReportCommand(),
+            CommandType.DeviceCapabilities => new DeviceCapabilitiesCommand(),
+            CommandType.LocalStatus => new LocalStatusCommand(),
+            CommandType.InputStatus => new InputStatusCommand(),
+            CommandType.OutputStatus => new OutputStatusCommand(),
+            CommandType.ReaderStatus => new ReaderStatusCommand(),
+            CommandType.OutputControl => new OutputControlCommand(),
+
+            CommandType.CommunicationSet => new CommunicationSetCommand(),
+            _ => null
+        };
+
+        command.Panel = _targetPanel;
+        command.ConnectionId = _connectionId;
+        command.DeviceAddress= _deviceAddress;
+
+        return command;
+    }
+
+
+    protected enum TestEventType
+    {
+        ConnectionLost,
+        ConnectionEstablished
+    }
+
+    private class EventCheckpoint
+    {
+        public TestEventType EventType { get; set; }
+
+        public TaskCompletionSource<bool> Tcs { get; set; }
+    }
+}
+
+public class TestConfiguration
+{
+    public DeviceConfiguration Device { get; } = new () { Address = IntegrationConsts.DefaultTestDeviceAddr };
+
+    internal PanelConfiguration Panel { get; } = new ();
+}
+
+public class PanelConfiguration
+{
+    internal Action<OutgoingMessage, IMessageSecureChannel> OnGetNextCommand { get; set; }
+
+    public bool TestDeviceProxyNeeded { get => OnGetNextCommand != null; }
+}
+
+
+internal class TestDeviceProxy : DeviceProxy
+{
+    private readonly PanelConfiguration _panelConfiguration;
+
+    public TestDeviceProxy(byte address, bool useCrc, bool useSecureChannel, 
+        byte[] secureChannelKey, PanelConfiguration panelConfiguration)
+        : base(address, useCrc, useSecureChannel, secureChannelKey) 
+    {
+        _panelConfiguration = panelConfiguration;
+    }
+
+    internal override OutgoingMessage GetNextCommandData(bool isPolling)
+    {
+        var command = base.GetNextCommandData(isPolling);
+        _panelConfiguration.OnGetNextCommand?.Invoke(command, MessageSecureChannel);
+        return command;
+    }
+}
+
+internal class TestDeviceProxyFactory : IDeviceProxyFactory
+{
+    private readonly PanelConfiguration _panelConfiguration;
+
+    internal TestDeviceProxyFactory(PanelConfiguration panelConfiguration)
+    {
+        _panelConfiguration = panelConfiguration;
+    }
+
+    public DeviceProxy Create(
+        byte address, bool useCrc, bool useSecureChannel, byte[] secureChannelKey = null)
+        => new TestDeviceProxy(address, useCrc, useSecureChannel, secureChannelKey, _panelConfiguration);
+}
+
+public abstract class TestCommand
+{
+    public ControlPanel Panel { get; set; }
+    public Guid ConnectionId { get; set; }
+    public byte DeviceAddress { get; set; }
+
+    public abstract Task<TestReply> Run();
+}
+
+public class TestReply
+{
+
+}
+
+public class IdReportCommand : TestCommand
+{
+    public override async Task<TestReply> Run() =>
+        new IdReportReply { DeviceIdentification = await Panel.IdReport(ConnectionId, DeviceAddress) };
+}
+
+public class IdReportReply : TestReply
+{
+    public DeviceIdentification DeviceIdentification { get; set; }
+}
+
+public class DeviceCapabilitiesCommand : TestCommand
+{
+    public override async Task<TestReply> Run() =>
+        new DeviceCapabilitiesReply { Response = await Panel.DeviceCapabilities(ConnectionId, DeviceAddress) };
+}
+
+public class DeviceCapabilitiesReply : TestReply
+{
+    public DeviceCapabilities Response { get; set; }
+}
+
+public class LocalStatusCommand : TestCommand
+{
+    public override async Task<TestReply> Run() =>
+        new LocalStatusReply { Response = await Panel.LocalStatus(ConnectionId, DeviceAddress) };
+}
+
+public class LocalStatusReply : TestReply
+{
+    public LocalStatus Response { get; set; }
+}
+
+public class InputStatusCommand : TestCommand
+{
+    public override async Task<TestReply> Run() =>
+        new InputStatusReply { Response = await Panel.InputStatus(ConnectionId, DeviceAddress) };
+}
+
+public class InputStatusReply : TestReply
+{
+    public InputStatus Response { get; set; }
+}
+
+public class OutputStatusCommand : TestCommand
+{
+    public override async Task<TestReply> Run() =>
+        new OutputStatusReply { Response = await Panel.OutputStatus(ConnectionId, DeviceAddress) };
+}
+
+public class OutputStatusReply : TestReply
+{
+    public OutputStatus Response { get; set; }
+}
+
+public class ReaderStatusCommand : TestCommand
+{
+    public override async Task<TestReply> Run() =>
+        new ReaderStatusReply { Response = await Panel.ReaderStatus(ConnectionId, DeviceAddress) };
+}
+
+public class ReaderStatusReply : TestReply
+{
+    public ReaderStatus Response { get; set; }
+}
+
+public class OutputControlCommand : TestCommand
+{
+    public OutputControls OutputControls { get; set; } = new OutputControls([
+        new OutputControl(0, OutputControlCode.Nop, 0)
+    ]);
+
+    public override async Task<TestReply> Run() =>
+        new OutputControlReply { Response = await Panel.OutputControl(ConnectionId, DeviceAddress, OutputControls) };
+}
+
+public class OutputControlReply : TestReply
+{
+    public ReturnReplyData<OutputStatus> Response { get; set; }
+}
+
+public class CommunicationSetCommand : TestCommand
+{
+    public Net.Model.CommandData.CommunicationConfiguration CommConfig { get; set; } = new(0, 9600);
+
+    public override async Task<TestReply> Run() =>
+        new CommunicationSetReply { Response = await Panel.CommunicationConfiguration(ConnectionId, DeviceAddress, CommConfig) };
+}
+
+public class CommunicationSetReply : TestReply
+{
+    public Net.Model.ReplyData.CommunicationConfiguration Response { get; set; }
+}

--- a/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
+++ b/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
@@ -2,15 +2,12 @@
 using Microsoft.Extensions.Logging;
 using System.Threading.Tasks;
 using NUnit.Framework;
-using OSDP.Net.Connections;
 using OSDP.Net.Model;
 using OSDP.Net.Model.CommandData;
 using OSDP.Net.Model.ReplyData;
 using DeviceCapabilities = OSDP.Net.Model.ReplyData.DeviceCapabilities;
 using System.Linq;
 using Moq;
-using System.Collections.Concurrent;
-using System.Collections;
 
 namespace OSDP.Net.Tests.IntegrationTests;
 
@@ -107,7 +104,7 @@ public class PeripheryDeviceTest : IntegrationTestFixtureBase
         await WaitForDeviceOnlineStatus();
 
         var newKey = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf };
-        var result = await _targetPanel.EncryptionKeySet(_connectionId, 0, 
+        var result = await _targetPanel.EncryptionKeySet(ConnectionId, 0, 
             new EncryptionKeyConfiguration(KeyType.SecureChannelBaseKey, newKey));
         Assert.True(result);
 
@@ -130,7 +127,7 @@ public class PeripheryDeviceTest : IntegrationTestFixtureBase
 
         byte newAddress = 20;
         var commSettings = new Net.Model.CommandData.CommunicationConfiguration(newAddress, 9600);
-        var results = await _targetPanel.CommunicationConfiguration(_connectionId, 0, commSettings);
+        var results = await _targetPanel.CommunicationConfiguration(ConnectionId, 0, commSettings);
 
         Assert.That(results.Address, Is.EqualTo(newAddress));
 
@@ -173,10 +170,10 @@ public class PeripheryDeviceTest : IntegrationTestFixtureBase
         var connLostCheckpoint = SetupCheckpointForExpectedTestEvent(TestEventType.ConnectionLost);
 
         int newBaudRate = 19200;
-        var commSettings = new Net.Model.CommandData.CommunicationConfiguration(_deviceAddress, newBaudRate);
-        var results = await _targetPanel.CommunicationConfiguration(_connectionId, 0, commSettings);
+        var commSettings = new Net.Model.CommandData.CommunicationConfiguration(DeviceAddress, newBaudRate);
+        var results = await _targetPanel.CommunicationConfiguration(ConnectionId, 0, commSettings);
 
-        Assert.AreEqual(results.Address, _deviceAddress);
+        Assert.AreEqual(results.Address, DeviceAddress);
         Assert.AreEqual(results.BaudRate, newBaudRate);
 
         await connLostCheckpoint;

--- a/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
+++ b/src/OSDP.Net.Tests/IntegrationTests/PeripheryDeviceTest.cs
@@ -104,7 +104,7 @@ public class PeripheryDeviceTest : IntegrationTestFixtureBase
         await WaitForDeviceOnlineStatus();
 
         var newKey = new byte[] { 0x0, 0x1, 0x2, 0x3, 0x4, 0x5, 0x6, 0x7, 0x8, 0x9, 0xa, 0xb, 0xc, 0xd, 0xe, 0xf };
-        var result = await _targetPanel.EncryptionKeySet(ConnectionId, 0, 
+        var result = await TargetPanel.EncryptionKeySet(ConnectionId, 0, 
             new EncryptionKeyConfiguration(KeyType.SecureChannelBaseKey, newKey));
         Assert.True(result);
 
@@ -127,7 +127,7 @@ public class PeripheryDeviceTest : IntegrationTestFixtureBase
 
         byte newAddress = 20;
         var commSettings = new Net.Model.CommandData.CommunicationConfiguration(newAddress, 9600);
-        var results = await _targetPanel.CommunicationConfiguration(ConnectionId, 0, commSettings);
+        var results = await TargetPanel.CommunicationConfiguration(ConnectionId, 0, commSettings);
 
         Assert.That(results.Address, Is.EqualTo(newAddress));
 
@@ -148,7 +148,7 @@ public class PeripheryDeviceTest : IntegrationTestFixtureBase
 
         await InitTestTargets();
 
-        _targetDevice.DeviceComSetUpdated += async (o, e) =>
+        TargetDevice.DeviceComSetUpdated += async (o, e) =>
         {
             TestContext.WriteLine("----- Received Device ComSet Updated EVENT -----");
 
@@ -156,8 +156,8 @@ public class PeripheryDeviceTest : IntegrationTestFixtureBase
             mockComSetUpdate.Object.Invoke(o, e);
 
             // Simulate what a "real" client would do when it got the request to change comm settings
-            await _targetDevice.StopListening();
-            _targetDevice.Dispose();
+            await TargetDevice.StopListening();
+            TargetDevice.Dispose();
 
             // Re-init the device with new baud rate
             InitTestTargetDevice(baudRate: e.NewBaudRate);
@@ -171,7 +171,7 @@ public class PeripheryDeviceTest : IntegrationTestFixtureBase
 
         int newBaudRate = 19200;
         var commSettings = new Net.Model.CommandData.CommunicationConfiguration(DeviceAddress, newBaudRate);
-        var results = await _targetPanel.CommunicationConfiguration(ConnectionId, 0, commSettings);
+        var results = await TargetPanel.CommunicationConfiguration(ConnectionId, 0, commSettings);
 
         Assert.AreEqual(results.Address, DeviceAddress);
         Assert.AreEqual(results.BaudRate, newBaudRate);

--- a/src/OSDP.Net.Tests/IntegrationTests/SecurityTests.cs
+++ b/src/OSDP.Net.Tests/IntegrationTests/SecurityTests.cs
@@ -43,9 +43,10 @@ namespace OSDP.Net.Tests.IntegrationTests
                 foreach (var commandType in disallowedCommands)
                 {
                     var command = BuildTestCommand(commandType);
-                    var ex = Assert.ThrowsAsync<NackReplyException>(() => command.Run(), $"command: {commandType}");
+                    var exception = Assert.ThrowsAsync<NackReplyException>(() => command.Run(), $"command: {commandType}");
+                    Assert.That(exception, Is.Not.Null);
                     Assert.That(
-                        ex.Reply.ErrorCode,
+                        exception.Reply.ErrorCode,
                         Is.EqualTo(Net.Model.ReplyData.ErrorCode.CommunicationSecurityNotMet),
                         $"command: {commandType}");
                 }
@@ -75,9 +76,10 @@ namespace OSDP.Net.Tests.IntegrationTests
 
             AddDeviceToPanel(IntegrationConsts.NonDefaultSCBK);
 
-            var ex = Assert.ThrowsAsync<NackReplyException>(() => TargetPanel.IdReport(_connectionId, _deviceAddress));
+            var exception = Assert.ThrowsAsync<NackReplyException>(() => TargetPanel.IdReport(ConnectionId, DeviceAddress));
+            Assert.That(exception, Is.Not.Null);
             Assert.That(
-                ex.Reply.ErrorCode,
+                exception.Reply.ErrorCode,
                 Is.EqualTo(Net.Model.ReplyData.ErrorCode.CommunicationSecurityNotMet));
         }
 
@@ -118,9 +120,10 @@ namespace OSDP.Net.Tests.IntegrationTests
                 foreach (var commandType in disallowedCommands)
                 {
                     var command = BuildTestCommand(commandType);
-                    var ex = Assert.ThrowsAsync<NackReplyException>(() => command.Run(), $"command: {commandType}");
+                    var exception = Assert.ThrowsAsync<NackReplyException>(() => command.Run(), $"command: {commandType}");
+                    Assert.That(exception, Is.Not.Null);
                     Assert.That(
-                        ex.Reply.ErrorCode,
+                        exception.Reply.ErrorCode,
                         Is.EqualTo(Net.Model.ReplyData.ErrorCode.CommunicationSecurityNotMet),
                         $"command: {commandType}");
                 }
@@ -222,9 +225,10 @@ namespace OSDP.Net.Tests.IntegrationTests
 
             AddDeviceToPanel(IntegrationConsts.NonDefaultSCBK);
 
-            var ex = Assert.ThrowsAsync<NackReplyException>(() => TargetPanel.IdReport(_connectionId, _deviceAddress));
+            var exception = Assert.ThrowsAsync<NackReplyException>(() => TargetPanel.IdReport(ConnectionId, DeviceAddress));
+            Assert.That(exception, Is.Not.Null);
             Assert.That(
-                ex.Reply.ErrorCode,
+                exception.Reply.ErrorCode,
                 Is.EqualTo(Net.Model.ReplyData.ErrorCode.CommunicationSecurityNotMet));
         }
     }

--- a/src/OSDP.Net.Tests/IntegrationTests/SecurityTests.cs
+++ b/src/OSDP.Net.Tests/IntegrationTests/SecurityTests.cs
@@ -1,0 +1,233 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+using OSDP.Net.Messages;
+
+namespace OSDP.Net.Tests.IntegrationTests
+{
+    public class SecurityTests : IntegrationTestFixtureBase
+    {
+        [Test]
+        public async Task GivenRequireSecurityWithSCBK_WhenSecChanNotEstablished_MostCommandsAreNotAllowed()
+        {
+            await InitTestTargets(cfg =>
+            {
+                cfg.RequireSecurity = true;
+                cfg.SecurityKey = IntegrationConsts.NonDefaultSCBK;
+            });
+
+            // The panel WILL NOT establish secure channel in this test before sending the set of commands
+            AddDeviceToPanel(useSecureChannel: false);
+
+            // By default, the OSDP protocol allows these commands to be sent to the PD even when secure channel
+            // is not established in the secure mode
+            var allowedCommands = new[] { 
+                CommandType.IdReport, CommandType.DeviceCapabilities, CommandType.CommunicationSet };
+            
+            // All other commands should not be allowed
+            var disallowedCommands = new[] {
+                CommandType.LocalStatus, CommandType.InputStatus, CommandType.OutputStatus,
+                CommandType.ReaderStatus, CommandType.OutputControl
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach (var commandType in allowedCommands)
+                {
+                    var command = BuildTestCommand(commandType);
+                    Assert.DoesNotThrowAsync(async () => {
+                        var reply = await command.Run();
+                        Assert.NotNull(reply, $"command: {commandType}");
+                    }, $"command: {commandType}");
+                }
+
+                foreach (var commandType in disallowedCommands)
+                {
+                    var command = BuildTestCommand(commandType);
+                    var ex = Assert.ThrowsAsync<NackReplyException>(() => command.Run(), $"command: {commandType}");
+                    Assert.That(
+                        ex.Reply.ErrorCode,
+                        Is.EqualTo(Net.Model.ReplyData.ErrorCode.CommunicationSecurityNotMet),
+                        $"command: {commandType}");
+                }
+            });
+        }
+
+        [Test]
+        public async Task GivenRequireSecurityWithSCBK_WhenSecChanEstablished_UnsecureCommandsNotAllowed()
+        {
+            await InitTestTargets(device =>
+            {
+                device.RequireSecurity = true;
+                device.SecurityKey = IntegrationConsts.NonDefaultSCBK;
+            },
+            panel =>
+            {
+                // Add a test-specific hook here so that right before IdReport command is sent, we will
+                // reset the secure channel thus forcing the report command to be sent unsecure to the PD
+                panel.OnGetNextCommand = (command, channel) =>
+                {
+                    if (command.Code == (byte)CommandType.IdReport)
+                    {
+                        channel.ResetSecureChannelSession();
+                    }
+                };
+            });
+
+            AddDeviceToPanel(IntegrationConsts.NonDefaultSCBK);
+
+            var ex = Assert.ThrowsAsync<NackReplyException>(() => TargetPanel.IdReport(_connectionId, _deviceAddress));
+            Assert.That(
+                ex.Reply.ErrorCode,
+                Is.EqualTo(Net.Model.ReplyData.ErrorCode.CommunicationSecurityNotMet));
+        }
+
+        [Test]
+        public async Task GivenRequireSecurityWithSCBK_WhenSecChanNotEstablished_PdMayChooseToLimitAllowedUnsecureCommands()
+        {
+            await InitTestTargets(cfg =>
+            {
+                cfg.RequireSecurity = true;
+                cfg.SecurityKey = IntegrationConsts.NonDefaultSCBK;
+
+                // PD instantiation overrides defaults to only allow IdReport command to be sent unsecured
+                cfg.AllowUnsecured = [CommandType.IdReport];
+            });
+
+            // The panel WILL NOT establish secure channel in this test before sending the set of commands
+            AddDeviceToPanel(useSecureChannel: false);
+
+            var allowedCommands = new[] { CommandType.IdReport };
+
+            // These commands would have been allowed by default but because we updated device configuration
+            // to not allow them, let's verify that they will now return a NAK
+            var disallowedCommands = new[] {
+                CommandType.DeviceCapabilities, CommandType.CommunicationSet
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach (var commandType in allowedCommands)
+                {
+                    var command = BuildTestCommand(commandType);
+                    Assert.DoesNotThrowAsync(async () => {
+                        var reply = await command.Run();
+                        Assert.NotNull(reply, $"command: {commandType}");
+                    }, $"command: {commandType}");
+                }
+
+                foreach (var commandType in disallowedCommands)
+                {
+                    var command = BuildTestCommand(commandType);
+                    var ex = Assert.ThrowsAsync<NackReplyException>(() => command.Run(), $"command: {commandType}");
+                    Assert.That(
+                        ex.Reply.ErrorCode,
+                        Is.EqualTo(Net.Model.ReplyData.ErrorCode.CommunicationSecurityNotMet),
+                        $"command: {commandType}");
+                }
+            });
+        }
+
+        [Test]
+        public async Task GivenRequiredSecurityWithDefaultSCBK_WhenSecChanNotEstablished_AllCommandsAreAllowed()
+        {
+            await InitTestTargets(cfg =>
+            {
+                cfg.RequireSecurity = true;
+                cfg.SecurityKey = IntegrationConsts.DefaultSCBK;
+            });
+
+            // The panel WILL NOT establish secure channel in this test before sending the set of commands
+            AddDeviceToPanel(useSecureChannel: false);
+
+            // By default, the OSDP protocol allows these commands to be sent to the PD even when secure channel
+            // is not established in the secure mode
+            var allowedCommands = new[] {
+                CommandType.IdReport, CommandType.DeviceCapabilities, CommandType.CommunicationSet,
+                CommandType.LocalStatus, CommandType.InputStatus, CommandType.OutputStatus,
+                CommandType.ReaderStatus, CommandType.OutputControl
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach (var commandType in allowedCommands)
+                {
+                    var command = BuildTestCommand(commandType);
+                    Assert.DoesNotThrowAsync(async () => {
+                        var reply = await command.Run();
+                        Assert.NotNull(reply, $"command: {commandType}");
+                    }, $"command: {commandType}");
+                }
+            });
+        }
+
+        [Test]
+        public async Task GivenNoRequireSecurity_WhenSecChanNotEstablished_AllCommandsAreAllowed()
+        {
+            await InitTestTargets(cfg =>
+            {
+                cfg.RequireSecurity = false;
+
+                // We have a non-default security key BUT we also told PD that security isn't 
+                // required
+                cfg.SecurityKey = IntegrationConsts.NonDefaultSCBK;
+            });
+
+            // The panel WILL NOT establish secure channel in this test before sending the set of commands
+            AddDeviceToPanel(useSecureChannel: false);
+
+            // By default, the OSDP protocol allows these commands to be sent to the PD even when secure channel
+            // is not established in the secure mode
+            var allowedCommands = new[] {
+                CommandType.IdReport, CommandType.DeviceCapabilities, CommandType.CommunicationSet,
+                CommandType.LocalStatus, CommandType.InputStatus, CommandType.OutputStatus,
+                CommandType.ReaderStatus, CommandType.OutputControl
+            };
+
+            Assert.Multiple(() =>
+            {
+                foreach (var commandType in allowedCommands)
+                {
+                    var command = BuildTestCommand(commandType);
+                    Assert.DoesNotThrowAsync(async () => {
+                        var reply = await command.Run();
+                        Assert.NotNull(reply, $"command: {commandType}");
+                    }, $"command: {commandType}");
+                }
+            });
+        }
+
+        [Test]
+        public async Task GivenNoRequireSecurity_WhenSecChanEstablished_UnsecureCommandsNotAllowed() 
+        {
+            await InitTestTargets(cfg =>
+            {
+                cfg.RequireSecurity = false;
+
+                // We have a non-default security key BUT we also told PD that security isn't 
+                // required
+                cfg.SecurityKey = IntegrationConsts.NonDefaultSCBK;
+            },
+            panel =>
+            {
+                // Add a test-specific hook here so that right before IdReport command is sent, we will
+                // reset the secure channel thus forcing the report command to be sent unsecure to the PD
+                panel.OnGetNextCommand = (command, channel) =>
+                {
+                    if (command.Code == (byte)CommandType.IdReport)
+                    {
+                        channel.ResetSecureChannelSession();
+                    }
+                };
+            });
+
+            AddDeviceToPanel(IntegrationConsts.NonDefaultSCBK);
+
+            var ex = Assert.ThrowsAsync<NackReplyException>(() => TargetPanel.IdReport(_connectionId, _deviceAddress));
+            Assert.That(
+                ex.Reply.ErrorCode,
+                Is.EqualTo(Net.Model.ReplyData.ErrorCode.CommunicationSecurityNotMet));
+        }
+    }
+}
+
+

--- a/src/OSDP.Net.sln.DotSettings
+++ b/src/OSDP.Net.sln.DotSettings
@@ -6,6 +6,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PIN/@EntryIndexedValue">PIN</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PIV/@EntryIndexedValue">PIV</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=UID/@EntryIndexedValue">UID</s:String>
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=SCBK/@EntryIndexedValue">SCBK</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=APDU/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=INCITS/@EntryIndexedValue">True</s:Boolean>

--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -40,11 +40,12 @@ namespace OSDP.Net
         private readonly Action<TraceEntry> _tracer;
         private readonly AutoResetEvent _commandAvailableEvent = new (false);
         private readonly AutoResetEvent _shutdownComplete = new (false);
+        private readonly IDeviceProxyFactory _deviceProxyFactory;
         
         private CancellationTokenSource _cancellationTokenSource;
 
         public Bus(IOsdpConnection connection, BlockingCollection<ReplyTracker> replies, TimeSpan pollInterval,
-            Action<TraceEntry> tracer,
+            Action<TraceEntry> tracer, IDeviceProxyFactory deviceProxyFactory,
             // ReSharper disable once ContextualLoggerProblem
             ILogger<ControlPanel> logger = null)
         {
@@ -54,6 +55,7 @@ namespace OSDP.Net
             _tracer = tracer;
             Id = Guid.NewGuid();
             _logger = logger;
+            _deviceProxyFactory = deviceProxyFactory;
         }
 
         private bool IsPolling => _pollInterval > TimeSpan.Zero;
@@ -128,7 +130,7 @@ namespace OSDP.Net
                     _configuredDevices.Remove(foundDevice);
                 }
 
-                var addedDevice = new DeviceProxy(address, useCrc, useSecureChannel, secureChannelKey);
+                var addedDevice = _deviceProxyFactory.Create(address, useCrc, useSecureChannel, secureChannelKey);
 
                 _configuredDevices.Add(addedDevice);
             }

--- a/src/OSDP.Net/ControlPanel.cs
+++ b/src/OSDP.Net/ControlPanel.cs
@@ -33,13 +33,17 @@ namespace OSDP.Net
         private TimeSpan _replyResponseTimeout = TimeSpan.FromSeconds(8);
         private readonly ConcurrentDictionary<int, SemaphoreSlim> _requestLocks = new();
         private readonly TimeSpan _timeToWaitToCheckOnData = TimeSpan.FromMilliseconds(10);
+        private readonly IDeviceProxyFactory _deviceProxyFactory;
 
         /// <summary>Initializes a new instance of the <see cref="T:OSDP.Net.ControlPanel" /> class.</summary>
         /// <param name="logger">The logger definition used for logging.</param>
-        public ControlPanel(ILogger<ControlPanel> logger = null)
+        public ControlPanel(ILogger<ControlPanel> logger = null) : this(null, logger) { }
+
+        internal ControlPanel(IDeviceProxyFactory deviceProxyFactory, ILogger<ControlPanel> logger = null)
         {
             _logger = logger;
-            
+            _deviceProxyFactory = deviceProxyFactory ?? new DeviceProxyFactory();
+
             Task.Factory.StartNew(() =>
             {
                 foreach (var reply in _replies.GetConsumingEnumerable())
@@ -117,6 +121,7 @@ namespace OSDP.Net
                     _replies,
                     pollInterval,
                     tracer,
+                    _deviceProxyFactory,
                     _logger);
 
                 _buses[newBus.Id] = newBus;

--- a/src/OSDP.Net/Device.cs
+++ b/src/OSDP.Net/Device.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
@@ -100,7 +101,13 @@ public class Device : IDisposable
                 incomingConnection, _deviceConfiguration.SecurityKey, loggerFactory: _loggerFactory)
             { 
                 Address = _deviceConfiguration.Address,
-                DefaultKeyAllowed = _deviceConfiguration.DefaultSecurityKeyAllowed
+                SecurityMode = !_deviceConfiguration.RequireSecurity
+                    ? SecurityMode.Unsecured
+                    : (_deviceConfiguration.SecurityKey == null ||
+                       _deviceConfiguration.SecurityKey.SequenceEqual(SecurityContext.DefaultKey))
+                    ? SecurityMode.InstallMode
+                    : SecurityMode.FullSecurity,
+                AllowUnsecured = _deviceConfiguration.AllowUnsecured ?? [],
             };
 
             while (incomingConnection.IsOpen)
@@ -476,18 +483,27 @@ public class DeviceConfiguration : ICloneable
     public byte Address { get; set; }
 
     /// <summary>
-    /// As described in D.8: Field Deployment and Configuration, this flag enables
-    /// "installation mode" which will allow SCBK-D (i.e. default security key) to be
-    /// accepted even if a different key has already been set on the device. This flag
-    /// should be used during setup and NOT for the operation of the device
+    /// Indicates whether or not device will require establishment of a secure
+    /// channel. When this value is 'true', PD will be initialized with SCBK (non-default 
+    /// SecurityKey) in full-security mode; or with SCBK_D in "installation
+    /// mode" if SecurityKey is not set to non-default installation value.
     /// </summary>
-    public bool DefaultSecurityKeyAllowed { get; set; }
+    public bool RequireSecurity { get; set; } = true;
 
     /// <summary>
     /// Security Key if one was previously set via osdp_KeySet command or some
     /// other out-of-band means
     /// </summary>
     public byte[] SecurityKey { get; set; } = SecurityContext.DefaultKey;
+
+    /// <summary>
+    /// List of commands the PD will allow to be sent unsecured when device is operating
+    /// in "Full Security" mode as defined by the OSDP spec. NOTE: per OSDP committee's
+    /// decision by default this list will include IdReport, DeviceCapabilities and CommSet
+    /// commands, but PD manufacturer can use this property to override that default
+    /// </summary>
+    public CommandType[] AllowUnsecured { get; set; } = [
+        CommandType.IdReport, CommandType.DeviceCapabilities, CommandType.CommunicationSet];
 
     /// <summary>
     /// Creates a new object that is a copy of the current instance

--- a/src/OSDP.Net/DeviceProxy.cs
+++ b/src/OSDP.Net/DeviceProxy.cs
@@ -92,7 +92,7 @@ internal class DeviceProxy : IComparable<DeviceProxy>
     /// </summary>
     /// <param name="isPolling">If false, only send commands in the queue</param>
     /// <returns>The next command always if polling, could be null if not polling</returns>
-    internal OutgoingMessage GetNextCommandData(bool isPolling)
+    internal virtual OutgoingMessage GetNextCommandData(bool isPolling)
     {
         if (_retryCommand != null)
         {
@@ -192,4 +192,16 @@ internal class DeviceProxy : IComparable<DeviceProxy>
     {
         return MessageSecureChannel.DecodePayload(payload.ToArray());
     }
+}
+
+internal interface IDeviceProxyFactory
+{
+    DeviceProxy Create(byte address, bool useCrc, bool useSecureChannel, byte[] secureChannelKey = null);
+}
+
+internal class DeviceProxyFactory : IDeviceProxyFactory
+{
+    public DeviceProxy Create(
+        byte address, bool useCrc, bool useSecureChannel, byte[] secureChannelKey = null)
+        => new DeviceProxy(address, useCrc, useSecureChannel, secureChannelKey);
 }

--- a/src/OSDP.Net/Messages/OutgoingMessage.cs
+++ b/src/OSDP.Net/Messages/OutgoingMessage.cs
@@ -24,18 +24,20 @@ internal class OutgoingMessage : Message
     internal byte[] BuildMessage(IMessageSecureChannel secureChannel)
     {
         var payload = PayloadData.BuildData();
-        if (secureChannel.IsSecurityEstablished && payload.Length > 0)
+        var securityEstablished = secureChannel != null && secureChannel.IsSecurityEstablished;
+
+        if (securityEstablished && payload.Length > 0)
         {
             payload = PadTheData(payload, 16, FirstPaddingByte);
         }
 
-        bool isSecurityBlockPresent = secureChannel.IsSecurityEstablished || PayloadData.IsSecurityInitialization;
+        bool isSecurityBlockPresent = securityEstablished || PayloadData.IsSecurityInitialization;
         var securityBlock = isSecurityBlockPresent ? PayloadData.SecurityControlBlock() : Array.Empty<byte>();
 
         int headerLength = StartOfMessageLength + securityBlock.Length + sizeof(ReplyType);
         int totalLength = headerLength + payload.Length +
                           (ControlBlock.UseCrc ? 2 : 1) +
-                          (secureChannel.IsSecurityEstablished ? MacSize : 0);
+                          (securityEstablished ? MacSize : 0);
         var buffer = new byte[totalLength];
         int currentLength = 0;
 
@@ -53,7 +55,7 @@ internal class OutgoingMessage : Message
 
         buffer[currentLength++] = PayloadData.Code;
 
-        if (secureChannel.IsSecurityEstablished)
+        if (securityEstablished)
         {
             secureChannel.EncodePayload(payload, buffer.AsSpan(currentLength));
             currentLength += payload.Length;

--- a/src/OSDP.Net/Model/ReplyData/InputStatus.cs
+++ b/src/OSDP.Net/Model/ReplyData/InputStatus.cs
@@ -1,5 +1,6 @@
+using OSDP.Net.Messages;
+using OSDP.Net.Messages.SecureChannel;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -8,16 +9,27 @@ namespace OSDP.Net.Model.ReplyData
     /// <summary>
     /// A input status report reply.
     /// </summary>
-    public class InputStatus
+    public class InputStatus : PayloadData
     {
-        private InputStatus()
+        /// <summary>
+        /// Initializes a new instance of InputStatus class
+        /// </summary>
+        /// <param name="statuses"></param>
+        public InputStatus(bool[] statuses)
         {
+            InputStatuses = statuses;
         }
+
+        /// <inheritdoc />
+        public override byte Code => (byte)ReplyType.InputStatusReport;
 
         /// <summary>
         /// Gets the all the PD's input statuses as an array ordered by input number.
         /// </summary>
-        public IEnumerable<bool> InputStatuses { get; private set; }
+        public bool[] InputStatuses { get; }
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<byte> SecurityControlBlock() => SecurityBlock.ReplyMessageWithDataSecurity;
 
         /// <summary>
         /// Parses the data.
@@ -26,8 +38,11 @@ namespace OSDP.Net.Model.ReplyData
         /// <returns>A input status report reply.</returns>
         internal static InputStatus ParseData(ReadOnlySpan<byte> data)
         {
-            return new InputStatus {InputStatuses = data.ToArray().Select(Convert.ToBoolean)};
+            return new InputStatus(data.ToArray().Select(Convert.ToBoolean).ToArray());
         }
+
+        /// <inheritdoc />
+        public override byte[] BuildData() => InputStatuses.Select(x => x ? (byte)0x00 : (byte)0x01).ToArray();
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/OSDP.Net/Model/ReplyData/LocalStatus.cs
+++ b/src/OSDP.Net/Model/ReplyData/LocalStatus.cs
@@ -1,3 +1,5 @@
+using OSDP.Net.Messages;
+using OSDP.Net.Messages.SecureChannel;
 using System;
 using System.Text;
 
@@ -6,26 +8,36 @@ namespace OSDP.Net.Model.ReplyData
     /// <summary>
     /// A local status report reply.
     /// </summary>
-    public class LocalStatus
+    public class LocalStatus : PayloadData
     {
         /// <summary>
-        /// Prevents a default instance of the <see cref="LocalStatus"/> class from being created.
+        /// Initializes a new instance of LocalStatus class
         /// </summary>
-        private LocalStatus()
+        /// <param name="tamper"></param>
+        /// <param name="powerFailure"></param>
+        public LocalStatus(bool tamper, bool powerFailure)
         {
+            Tamper = tamper;
+            PowerFailure = powerFailure;
         }
+
+        /// <inheritdoc />
+        public override byte Code => (byte)ReplyType.LocalStatusReport;
 
         /// <summary>
         /// Gets a value indicating whether this PD is tamper.
         /// </summary>
         /// <value><c>true</c> if tamper; otherwise, <c>false</c>.</value>
-        public bool Tamper { get; private set; }
+        public bool Tamper { get; }
 
         /// <summary>
         /// Gets a value indicating whether this PD is experiencing a power failure.
         /// </summary>
         /// <value><c>true</c> if power failure; otherwise, <c>false</c>.</value>
-        public bool PowerFailure { get; private set; }
+        public bool PowerFailure { get; }
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<byte> SecurityControlBlock() => SecurityBlock.ReplyMessageWithDataSecurity;
 
         /// <summary>Parses the data.</summary>
         /// <param name="data">The data.</param>
@@ -39,14 +51,14 @@ namespace OSDP.Net.Model.ReplyData
                 throw new Exception("Invalid size for the data");
             }
 
-            var localStatus = new LocalStatus
-            {
-                Tamper = Convert.ToBoolean(dataArray[0]),
-                PowerFailure = Convert.ToBoolean(dataArray[1])
-            };
-
-            return localStatus;
+            return new LocalStatus(
+                Convert.ToBoolean(dataArray[0]), Convert.ToBoolean(dataArray[1]));
         }
+
+        /// <inheritdoc />
+        public override byte[] BuildData() => [
+            Tamper ? (byte)0x01 : (byte)0x00, 
+            PowerFailure ? (byte)0x01 : (byte)0x00];
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/OSDP.Net/Model/ReplyData/OutputStatus.cs
+++ b/src/OSDP.Net/Model/ReplyData/OutputStatus.cs
@@ -1,5 +1,6 @@
+using OSDP.Net.Messages;
+using OSDP.Net.Messages.SecureChannel;
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
@@ -8,37 +9,44 @@ namespace OSDP.Net.Model.ReplyData
     /// <summary>
     /// A output status report reply.
     /// </summary>
-    public class OutputStatus
+    public class OutputStatus : PayloadData
     {
         /// <summary>
         /// Prevents a default instance of the <see cref="OutputStatus"/> class from being created.
         /// </summary>
-        private OutputStatus()
+        public OutputStatus(bool[] statuses)
         {
+            OutputStatuses = statuses;
         }
+
+        /// <inheritdoc />
+        public override byte Code => (byte)ReplyType.InputStatusReport;
 
         /// <summary>
         /// Gets the all the PDs output statuses as an array ordered by output number.
         /// </summary>
-        public IEnumerable<bool> OutputStatuses { get; private set; }
+        public bool[] OutputStatuses { get; }
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<byte> SecurityControlBlock() => SecurityBlock.ReplyMessageWithDataSecurity;
 
         /// <summary>Parses the message payload bytes</summary>
         /// <param name="data">Message payload as bytes</param>
         /// <returns>An instance of OutputStatus representing the message payload</returns>
         public static OutputStatus ParseData(ReadOnlySpan<byte> data)
         {
-            return new OutputStatus {OutputStatuses = data.ToArray().Select(Convert.ToBoolean)};
+            return new OutputStatus(data.ToArray().Select(Convert.ToBoolean).ToArray());
         }
 
-        /// <inheritdoc/>
-        public override string ToString() => ToString(0);
+        /// <inheritdoc />
+        public override byte[] BuildData() => OutputStatuses.Select(x => x ? (byte)0x00 : (byte)0x01).ToArray();
 
         /// <summary>
         /// Returns a string representation of the current object
         /// </summary>
         /// <param name="indent">Number of ' ' chars to add to beginning of every line</param>
         /// <returns>String representation of the current object</returns>
-        public string ToString(int indent)
+        public override string ToString(int indent)
         {
             var padding = new string(' ', indent);
             byte outputNumber = 0;

--- a/src/OSDP.Net/Model/ReplyData/ReaderStatus.cs
+++ b/src/OSDP.Net/Model/ReplyData/ReaderStatus.cs
@@ -1,33 +1,46 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using OSDP.Net.Messages;
+using OSDP.Net.Messages.SecureChannel;
 
 namespace OSDP.Net.Model.ReplyData
 {
     /// <summary>
     /// A reader status report reply.
     /// </summary>
-    public class ReaderStatus
+    public class ReaderStatus : PayloadData
     {
-        private ReaderStatus()
+        /// <summary>
+        /// Creates a new instance of ReaderStatus class
+        /// </summary>
+        /// <param name="statuses"></param>
+        public ReaderStatus(ReaderTamperStatus[] statuses)
         {
+            ReaderTamperStatuses = statuses;
         }
+
+        /// <inheritdoc />
+        public override byte Code => (byte)ReplyType.ReaderStatusReport;
 
         /// <summary>
         /// Gets the all the PDs reader statuses as an array ordered by reader number.
         /// </summary>
-        public IEnumerable<ReaderTamperStatus> ReaderTamperStatuses { get; private set; }
+        public ReaderTamperStatus[] ReaderTamperStatuses { get; }
+
+        /// <inheritdoc />
+        public override ReadOnlySpan<byte> SecurityControlBlock() => SecurityBlock.ReplyMessageWithDataSecurity;
 
         /// <summary>Parses the message payload bytes</summary>
         /// <param name="data">Message payload as bytes</param>
         /// <returns>An instance of ReaderStatus representing the message payload</returns>
         internal static ReaderStatus ParseData(ReadOnlySpan<byte> data)
         {
-            return new ReaderStatus
-                {ReaderTamperStatuses = data.ToArray().Select(status => (ReaderTamperStatus) status)};
+            return new ReaderStatus(data.ToArray().Select(status => (ReaderTamperStatus) status).ToArray());
         }
+
+        /// <inheritdoc />
+        public override byte[] BuildData() => ReaderTamperStatuses.Select(x => (byte)x).ToArray();
 
         /// <inheritdoc />
         public override string ToString()

--- a/src/samples/CardReader/Program.cs
+++ b/src/samples/CardReader/Program.cs
@@ -18,7 +18,7 @@ internal class Program
         string portName = osdpSection["PortName"] ?? throw new NullReferenceException("A port name is required in the configuration file.");
         int baudRate = int.Parse(osdpSection["BaudRate"] ?? "9600");
         byte deviceAddress = byte.Parse(osdpSection["DeviceAddress"] ?? "0");
-        bool defaultSecurityKeyAllowed = bool.Parse(osdpSection["DefaultSecurityKeyAllowed"] ?? "False");
+        bool requireSecurity = bool.Parse(osdpSection["RequireSecurity"] ?? "False");
         var securityKey = System.Text.Encoding.ASCII.GetBytes(osdpSection["SecurityKey"] ?? "0011223344556677889900AABBCCDDEEFF");
 
         var loggerFactory = LoggerFactory.Create(builder =>
@@ -33,7 +33,7 @@ internal class Program
         var deviceConfiguration = new DeviceConfiguration
         {
             Address = deviceAddress,
-            DefaultSecurityKeyAllowed = defaultSecurityKeyAllowed,
+            RequireSecurity = requireSecurity,
             SecurityKey = securityKey
         };
         

--- a/src/samples/CardReader/appsettings.json
+++ b/src/samples/CardReader/appsettings.json
@@ -3,7 +3,7 @@
     "PortName": "COM4",
     "BaudRate": "9600",
     "DeviceAddress": "0",
-    "DefaultSecurityKeyAllowed": "False",
+    "RequireSecurity": "False",
     "SecurityKey": "0011223344556677889900AABBCCDDEEFF"
   }
 }


### PR DESCRIPTION
This commit introduces the three PD security modes as defined by the spec:
- Full Security (RequireSecurity=true w/ non-default SCBK)
- Installation Mode (RequireSecurity=true w/ default SCBK)
- Unsecure (RequireSecurity=false)

And includes a set of integration tests to verify the various permutations underwhich PD and ACU sides of OSDP comms may be initialized