### PR TITLE
Use 2-byte TOTAL and OFFSET in osdp_CRAUTH message fragments

### DIFF
--- a/src/OSDP.Net/ControlPanel.cs
+++ b/src/OSDP.Net/ControlPanel.cs
@@ -501,7 +501,8 @@ namespace OSDP.Net
                     reply = await SendCommand(connectionId, address, new Model.CommandData.ManufacturerSpecific(
                             manufacturerSpecific.VendorCode, manufactureCommandCode.Concat(
                                 new MessageDataFragment(totalSize, offset, fragmentSize,
-                                        manufactureCommandData.Skip(offset).Take(fragmentSize).ToArray()).BuildData()
+                                        manufactureCommandData.Skip(offset).Take(fragmentSize).ToArray(), 
+                                        MessageDataFragmentFieldSize.FourBytes).BuildData()
                                     .ToArray()).ToArray()), cancellationToken)
                         .ConfigureAwait(false);
 
@@ -687,7 +688,8 @@ namespace OSDP.Net
                 var reply = await SendCommand(connectionId, address,
             new FileTransferFragment(fileType,
                 new MessageDataFragment(totalSize, offset, nextFragmentSize,
-                    fileData.Skip(offset).Take(nextFragmentSize).ToArray())),
+                    fileData.Skip(offset).Take(nextFragmentSize).ToArray(), 
+                    MessageDataFragmentFieldSize.FourBytes)),
                         cancellationToken, throwOnNak: false)
                     .ConfigureAwait(false);
 
@@ -987,7 +989,8 @@ namespace OSDP.Net
                     await SendCommand(connectionId, address, new AuthenticationChallengeFragment(
                             new MessageDataFragment(totalSize, offset, fragmentSize,
                                 requestData.Skip(offset).Take((ushort)Math.Min(fragmentSize, totalSize - offset))
-                                    .ToArray())), cancellationToken)
+                                    .ToArray(), 
+                                MessageDataFragmentFieldSize.TwoBytes)), cancellationToken)
                         .ConfigureAwait(false);
 
                     offset += fragmentSize;

--- a/src/OSDP.Net/Model/CommandData/AuthenticationChallengeFragment.cs
+++ b/src/OSDP.Net/Model/CommandData/AuthenticationChallengeFragment.cs
@@ -34,6 +34,6 @@ public class AuthenticationChallengeFragment(MessageDataFragment fragment) : Com
     /// <returns>An instance of AuthenticationChallengeFragment representing the message payload</returns>
     public static AuthenticationChallengeFragment ParseData(ReadOnlySpan<byte> data)
     {
-        return new AuthenticationChallengeFragment(MessageDataFragment.ParseData(data));
+        return new AuthenticationChallengeFragment(MessageDataFragment.ParseData(data, MessageDataFragmentFieldSize.TwoBytes));
     }
 }

--- a/src/OSDP.Net/Model/CommandData/FileTransferFragment.cs
+++ b/src/OSDP.Net/Model/CommandData/FileTransferFragment.cs
@@ -53,6 +53,6 @@ internal class FileTransferFragment : CommandData
     /// <returns>An instance of FileTransferFragment representing the message payload</returns>
     public static FileTransferFragment ParseData(ReadOnlySpan<byte> data)
     {
-        return new FileTransferFragment(data[0], MessageDataFragment.ParseData(data.Slice(1)));
+        return new FileTransferFragment(data[0], MessageDataFragment.ParseData(data.Slice(1), MessageDataFragmentFieldSize.FourBytes));
     }
 }

--- a/src/OSDP.Net/Model/CommandData/MessageDataFragment.cs
+++ b/src/OSDP.Net/Model/CommandData/MessageDataFragment.cs
@@ -1,14 +1,33 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using OSDP.Net.Messages;
 
 namespace OSDP.Net.Model.CommandData
 {
     /// <summary>
+    /// Defines the field size used for the <see cref="MessageDataFragment.TotalSize"/> and
+    /// <see cref="MessageDataFragment.Offset"/> values.
+    /// </summary>
+    public enum MessageDataFragmentFieldSize
+    {
+        /// <summary>
+        /// Use 2-byte unsigned integer fields.
+        /// </summary>
+        TwoBytes,
+
+        /// <summary>
+        /// Use 4-byte signed integer fields.
+        /// </summary>
+        FourBytes
+    }
+
+    /// <summary>
     /// Represents a fragment of data for a multipart message.
     /// </summary>
     public class MessageDataFragment
     {
+        private readonly MessageDataFragmentFieldSize sizeAndOffsetFieldSize;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="MessageDataFragment"/> class.
         /// </summary>
@@ -16,12 +35,15 @@ namespace OSDP.Net.Model.CommandData
         /// <param name="offset">Offset of the current message</param>
         /// <param name="fragmentSize">Size of the fragment</param>
         /// <param name="dataFragment">Message fragment data</param>
-        public MessageDataFragment(int totalSize, int offset, ushort fragmentSize, byte[] dataFragment)
+        /// <param name="sizeAndOffsetFieldSize">The field size used for <see cref="TotalSize"/> and <see cref="Offset"/>.</param>
+        public MessageDataFragment(int totalSize, int offset, ushort fragmentSize, byte[] dataFragment,
+            MessageDataFragmentFieldSize sizeAndOffsetFieldSize)
         {
             TotalSize = totalSize;
             Offset = offset;
             FragmentSize = fragmentSize;
             DataFragment = dataFragment;
+            this.sizeAndOffsetFieldSize = sizeAndOffsetFieldSize;
         }
 
         /// <summary>
@@ -46,9 +68,10 @@ namespace OSDP.Net.Model.CommandData
 
         internal ReadOnlySpan<byte> BuildData()
         {
+            var useTwoByteFields = sizeAndOffsetFieldSize == MessageDataFragmentFieldSize.TwoBytes;
             var data = new List<byte>();
-            data.AddRange(Message.ConvertIntToBytes(TotalSize));
-            data.AddRange(Message.ConvertIntToBytes(Offset));
+            data.AddRange(useTwoByteFields ? Message.ConvertShortToBytes((ushort)TotalSize) : Message.ConvertIntToBytes(TotalSize));
+            data.AddRange(useTwoByteFields ? Message.ConvertShortToBytes((ushort)Offset) : Message.ConvertIntToBytes(Offset));
             data.AddRange(Message.ConvertShortToBytes(FragmentSize));
             data.AddRange(DataFragment);
             return data.ToArray();
@@ -56,14 +79,41 @@ namespace OSDP.Net.Model.CommandData
 
         /// <summary>Parses the message payload bytes</summary>
         /// <param name="data">Message payload as bytes</param>
+        /// <param name="sizeAndOffsetFieldSize">The field size used for <see cref="TotalSize"/> and <see cref="Offset"/>.</param>
         /// <returns>An instance of MessageDataFragment representing the message payload</returns>
-        public static MessageDataFragment ParseData(ReadOnlySpan<byte> data)
+        public static MessageDataFragment ParseData(ReadOnlySpan<byte> data,
+            MessageDataFragmentFieldSize sizeAndOffsetFieldSize)
         {
+            var dataOffset = 0;
+
+            var totalSize = ReadValue(sizeAndOffsetFieldSize, data, ref dataOffset);
+            var offset = ReadValue(sizeAndOffsetFieldSize, data, ref dataOffset);
+            var fragmentSize = (ushort)ReadValue(MessageDataFragmentFieldSize.TwoBytes, data, ref dataOffset);
+            var fragmentData = data.Slice(dataOffset).ToArray();
+
             return new MessageDataFragment(
-                Message.ConvertBytesToInt(data.Slice(0, 4).ToArray()),
-                Message.ConvertBytesToInt(data.Slice(4, 4).ToArray()),
-                Message.ConvertBytesToUnsignedShort(data.Slice(8, 2).ToArray()),
-                data.Slice(10).ToArray());
+               totalSize,
+               offset,
+               fragmentSize,
+               fragmentData,
+               sizeAndOffsetFieldSize);
+
+            static int ReadValue(MessageDataFragmentFieldSize fieldSize, ReadOnlySpan<byte> data, ref int offset)
+            {
+                switch (fieldSize)
+                {
+                    case MessageDataFragmentFieldSize.TwoBytes:
+                        var twoByteValue = Message.ConvertBytesToUnsignedShort(data.Slice(offset, 2));
+                        offset += 2;
+                        return twoByteValue;
+                    case MessageDataFragmentFieldSize.FourBytes:
+                        var fourByteValue = Message.ConvertBytesToInt(data.Slice(offset, 4).ToArray());
+                        offset += 4;
+                        return fourByteValue;
+                    default:
+                        throw new ArgumentOutOfRangeException(nameof(fieldSize), fieldSize, null);
+                }
+            }
         }
     }
 }

--- a/src/OSDP.Net/Model/Packet.cs
+++ b/src/OSDP.Net/Model/Packet.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using OSDP.Net.Messages;
 using OSDP.Net.Model.CommandData;
@@ -153,7 +153,7 @@ public class Packet : IPacket
             case Messages.CommandType.GenerateChallenge:
                 return null;
             case Messages.CommandType.AuthenticateChallenge:
-                return MessageDataFragment.ParseData(RawPayloadData);
+                return MessageDataFragment.ParseData(RawPayloadData, MessageDataFragmentFieldSize.TwoBytes);
             case Messages.CommandType.KeepActive:
                 return null;
         }

--- a/test/OSDP.Net.Tests/Messages/CommandOutgoingMessageTest.cs
+++ b/test/OSDP.Net.Tests/Messages/CommandOutgoingMessageTest.cs
@@ -107,7 +107,7 @@ internal class CommandOutgoingMessageTest
         device.MessageControl.IncrementSequence(1);
 
         var outgoingMessage = new OutgoingMessage(device.Address, device.MessageControl,
-            new FileTransferFragment(3, new MessageDataFragment(1000, 10, 5, new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 })));
+            new FileTransferFragment(3, new MessageDataFragment(1000, 10, 5, new byte[] { 0x01, 0x02, 0x03, 0x04, 0x05 }, MessageDataFragmentFieldSize.FourBytes)));
 
         return BitConverter.ToString(outgoingMessage.BuildMessage(CreateSecureChannel(device.UseSecureChannel)));
     }

--- a/test/OSDP.Net.Tests/Model/CommandData/FileTransferFragmentTest.cs
+++ b/test/OSDP.Net.Tests/Model/CommandData/FileTransferFragmentTest.cs
@@ -1,4 +1,4 @@
-﻿using NUnit.Framework;
+using NUnit.Framework;
 using OSDP.Net.Messages;
 using OSDP.Net.Messages.SecureChannel;
 using OSDP.Net.Model.CommandData;
@@ -13,7 +13,7 @@ internal class FileTransferFragmentTest
         0x01, 0x0A, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x05, 0x00, 0x09, 0x08, 0x07, 0x06, 0x05
     ];
 
-    private FileTransferFragment TestFileTransferFragment => new(0x01, new MessageDataFragment(10, 0, 5, [0x09, 0x08, 0x07, 0x06, 0x05]));
+    private FileTransferFragment TestFileTransferFragment => new(0x01, new MessageDataFragment(10, 0, 5, [0x09, 0x08, 0x07, 0x06, 0x05], MessageDataFragmentFieldSize.FourBytes));
 
     [Test]
     public void CheckConstantValues()


### PR DESCRIPTION
Fix incorrect field sizes in osdp_CRAUTH message: TOTAL and OFFSET were implemented as 4-byte values, but are defined as 2-byte little-endian integers per OSDP spec Table 33.

This caused `ControlPanel.AuthenticationChallenge` to send invalid messages that PDs could not interpret.