### PR TITLE
Retry commands that fail due to osdp_BUSY

### DIFF
--- a/src/OSDP.Net/Bus.cs
+++ b/src/OSDP.Net/Bus.cs
@@ -317,7 +317,7 @@ namespace OSDP.Net
                                 break;
                             default:
                                 _logger?.LogDebug($"[{Connection}] Retrying command {commandMessage} on connection {Id} because \"{exception.Message}\".");
-                                device.RetryCommand(commandMessage.PayloadData as CommandData);
+                                device.RetryCommand(commandMessage.PayloadData as CommandData, isBusyRetry: false);
                                 break;
                         }
 
@@ -336,7 +336,15 @@ namespace OSDP.Net
 
                     try
                     {
-                        ProcessReply(reply, device);
+                        if (reply.ReplyMessage.Type == (byte)ReplyType.Busy)
+                        {
+                            _logger?.LogDebug($"[{Connection}] Retrying command {commandMessage} on connection {Id} because the device is busy.");
+                            device.RetryCommand(commandMessage.PayloadData as CommandData, isBusyRetry: true);
+                        }
+                        else
+                        {
+                            ProcessReply(reply, device);
+                        }
                     }
                     catch (Exception exception)
                     {

--- a/src/OSDP.Net/DeviceProxy.cs
+++ b/src/OSDP.Net/DeviceProxy.cs
@@ -12,11 +12,13 @@ namespace OSDP.Net;
 internal class DeviceProxy : IComparable<DeviceProxy>
 {
     private const int RetryAmount = 2;
+    private const int BusyRetryAmount = 10;
 
     private readonly ConcurrentQueue<CommandData> _commands = new();
     private readonly bool _useSecureChannel;
     
     private int _counter = RetryAmount;
+    private bool _counterIsBusyRetry;
     private DateTime _lastValidReply = DateTime.MinValue;
     private CommandData _retryCommand;
 
@@ -140,8 +142,15 @@ internal class DeviceProxy : IComparable<DeviceProxy>
     /// Store command for retry
     /// </summary>
     /// <param name="command"></param>
-    internal void RetryCommand(CommandData command)
+    /// <param name="isBusyRetry"></param>
+    internal void RetryCommand(CommandData command, bool isBusyRetry = false)
     {
+        if (_counterIsBusyRetry != isBusyRetry)
+        {
+            _counter = isBusyRetry ? BusyRetryAmount : RetryAmount;
+            _counterIsBusyRetry = isBusyRetry;
+        }
+
         if (_counter-- > 0)
         {
             _retryCommand = command;
@@ -149,7 +158,7 @@ internal class DeviceProxy : IComparable<DeviceProxy>
         else
         {
             _retryCommand = null;
-            _counter = RetryAmount;
+            _counter = isBusyRetry ? BusyRetryAmount : RetryAmount;
         }
     }
 
@@ -162,6 +171,7 @@ internal class DeviceProxy : IComparable<DeviceProxy>
             
         // Reset retry counter
         _counter = RetryAmount;
+        _counterIsBusyRetry = false;
     }
 
     internal void InitializeSecureChannel(byte[] payload, byte[] secureBlockData)

--- a/src/OSDP.Net/DeviceProxy.cs
+++ b/src/OSDP.Net/DeviceProxy.cs
@@ -12,7 +12,7 @@ namespace OSDP.Net;
 internal class DeviceProxy : IComparable<DeviceProxy>
 {
     private const int RetryAmount = 2;
-    private const int BusyRetryAmount = 10;
+    private const int BusyRetryAmount = 20;
 
     private readonly ConcurrentQueue<CommandData> _commands = new();
     private readonly bool _useSecureChannel;


### PR DESCRIPTION
**Retry logic updates:**

* `DeviceProxy` now tracks busy retries separately using `BusyRetryAmount`.
* `RetryCommand` now accepts an `isBusyRetry` parameter, which determines whether to use the normal retry limit or the busy retry limit.
* The retry count and busy retry state are reset once the device returns a valid response.

**Polling and command handling updates:**

* In `Bus.cs`, busy responses are now logged and retried using the busy retry path.
* Other retry scenarios now explicitly pass `isBusyRetry: false`, so non-busy failures (timeouts) continue to use the existing retry behavior.
